### PR TITLE
feat: return the people a company search reads off its pages

### DIFF
--- a/apps/internal/src/components/research/findings/prospect-scan-view.tsx
+++ b/apps/internal/src/components/research/findings/prospect-scan-view.tsx
@@ -40,7 +40,7 @@ import {
 /**
  * Renders a `prospect_scan_v1` research finding. Each prospect carries
  * a `why_relevant` rationale + optional industry/countries/location/tax_id +
- * citations.
+ * the people its pages named + citations.
  *
  * A prospect the run could not confirm as a real trading company still belongs on
  * the list — the small firms a scan is really for are the ones with the thinnest
@@ -64,6 +64,13 @@ type ProspectEntry = {
 	readonly countries?: ReadonlyArray<string>
 	readonly location?: string
 	readonly why_relevant: string
+	// The people the company's own pages name. A list of firms is worth far more
+	// with somebody to ask for on each, so they travel on the row rather than
+	// waiting for a second run about one company.
+	readonly contacts?: ReadonlyArray<{
+		readonly name: string
+		readonly role?: string
+	}>
 	readonly unconfirmed_reason?: string
 	// Doubt the run did not put into words but the engine established on its own, so
 	// the wording belongs here rather than in the finding.
@@ -248,6 +255,22 @@ function ProspectRow({ prospect }: { readonly prospect: ProspectEntry }) {
 							<Trans>Tax ID</Trans>
 						</FieldKey>
 						<FieldValue>{prospect.tax_id}</FieldValue>
+					</FieldRow>
+				) : null}
+				{prospect.contacts !== undefined && prospect.contacts.length > 0 ? (
+					<FieldRow>
+						<FieldKey>
+							<Trans>People</Trans>
+						</FieldKey>
+						<FieldValue data-testid='prospect-contacts'>
+							{prospect.contacts
+								.map(person =>
+									person.role === undefined
+										? person.name
+										: `${person.name} — ${person.role}`,
+								)
+								.join(', ')}
+						</FieldValue>
 					</FieldRow>
 				) : null}
 			</FieldsTable>

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -4491,6 +4491,7 @@ msgstr "Accions de pagament pendents"
 msgid "Pending review"
 msgstr "Pendent de revisió"
 
+#: src/components/research/findings/prospect-scan-view.tsx
 #: src/routes/companies/$slug.tsx
 #: src/routes/companies/$slug.tsx
 msgid "People"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -4491,6 +4491,7 @@ msgstr "Pending paid actions"
 msgid "Pending review"
 msgstr "Pending review"
 
+#: src/components/research/findings/prospect-scan-view.tsx
 #: src/routes/companies/$slug.tsx
 #: src/routes/companies/$slug.tsx
 msgid "People"

--- a/packages/research/src/application/about-pages.test.ts
+++ b/packages/research/src/application/about-pages.test.ts
@@ -95,3 +95,53 @@ describe('aboutPageCandidates', () => {
 		})
 	})
 })
+
+describe('the pages a live search actually offered', () => {
+	describe('when a section only ever talks about other things', () => {
+		it('should refuse it, however much its words look like an about page', () => {
+			// GIVEN the four pages a real Girona scan picked before this: a press
+			// release whose title happens to say "sobre", and a portfolio entry
+			// whose title happens to say "management"
+			const picked = aboutPageCandidates(
+				[
+					'https://www.bellmasenginyers.cat/ca/actualitat-i-noticies/nota-aclaridora-sobre-l-aplicacio-de-la-instruccio/',
+					'https://www.bellmasenginyers.cat/ca/equip',
+				],
+				'bellmasenginyers.cat',
+				4,
+			)
+
+			// THEN only the team page, and the press release is left alone
+			expect(picked).toEqual(['https://www.bellmasenginyers.cat/ca/equip'])
+		})
+
+		it('should refuse a portfolio entry that names a discipline', () => {
+			// GIVEN a project page whose slug carries "management"
+			const picked = aboutPageCandidates(
+				[
+					'https://enigest.com/ca/portfolio/project-management-i-direccio-dobra/',
+				],
+				'enigest.com',
+				4,
+			)
+
+			// THEN nothing: a portfolio entry names the work, never the staff
+			expect(picked).toEqual([])
+		})
+	})
+
+	describe('when a Catalan site spells its team page the short way', () => {
+		it('should rank it above the contact form', () => {
+			// GIVEN the real EGEIN site, whose roster lives at /ca/equip and which
+			// also carries a contact page
+			const picked = aboutPageCandidates(
+				['https://egein.com/ca/contacte', 'https://egein.com/ca/equip'],
+				'egein.com',
+				4,
+			)
+
+			// THEN the forty-two people come first
+			expect(picked[0]).toBe('https://egein.com/ca/equip')
+		})
+	})
+})

--- a/packages/research/src/application/about-pages.ts
+++ b/packages/research/src/application/about-pages.ts
@@ -18,6 +18,13 @@ import { pathOf } from './source-key'
 // carries: people first (leaders and their titles), then the about/location pages,
 // then a contact page as a last resort. Spans several languages so a non-English site
 // is still covered.
+//
+// Matched as substrings, so a word that is the front of another covers both:
+// 'equip' catches the Catalan /equip and the Spanish /equipo and the French
+// /equipe at once. It is listed rather than left to 'equipo' because the shorter
+// spelling is the one a Catalan site uses — egein.com/ca/equip lists forty-two
+// people with their titles, and without it that page fell to the about band and
+// lost to a contact form.
 const TEAM_HINTS = [
 	'team',
 	'leadership',
@@ -26,8 +33,7 @@ const TEAM_HINTS = [
 	'staff',
 	'directors',
 	'board',
-	'equipo',
-	'equipe',
+	'equip',
 	'leaders',
 ]
 const ABOUT_HINTS = [
@@ -53,6 +59,13 @@ const CONTACT_HINTS = ['contact', 'contacto', 'contacte', 'kontakt', 'contatti']
 const NON_PAGE_SEGMENTS = new Set([
 	'blog',
 	'news',
+	'actualitat',
+	'actualidad',
+	'noticies',
+	'noticias',
+	'portfolio',
+	'projectes',
+	'proyectos',
 	'article',
 	'articles',
 	'post',
@@ -63,10 +76,18 @@ const NON_PAGE_SEGMENTS = new Set([
 	'media',
 ])
 
+// Whether any word of a segment is one of these. Split rather than compared whole,
+// because a section is written as a phrase as often as a word — "actualitat-i-
+// noticies" is the news, and matching the segment exactly let a press release
+// through as a page that would name the staff, then spent a fetch on it.
+const segmentNames = (segment: string, words: ReadonlySet<string>): boolean =>
+	segment.split(/[^a-z0-9]+/).some(word => word !== '' && words.has(word))
+
 // Which band a path falls in, or 3 (not a candidate) when no hint matches or it sits
-// under a blog/news section.
+// in a section that only ever talks about other things.
 const bandOf = (path: string): number => {
-	if (path.split('/').some(segment => NON_PAGE_SEGMENTS.has(segment))) return 3
+	if (path.split('/').some(segment => segmentNames(segment, NON_PAGE_SEGMENTS)))
+		return 3
 	if (TEAM_HINTS.some(hint => path.includes(hint))) return 0
 	if (ABOUT_HINTS.some(hint => path.includes(hint))) return 1
 	if (CONTACT_HINTS.some(hint => path.includes(hint))) return 2
@@ -82,6 +103,14 @@ export const aboutPageCandidates = (
 	links: ReadonlyArray<string>,
 	host: string,
 	max: number,
+	/**
+	 * The weakest kind of page worth taking: 0 a team page, 1 an about page, 2 a
+	 * contact page. A caller filling in a company's location takes all three,
+	 * because an address is on a contact page as often as anywhere. A caller after
+	 * the company's PEOPLE stops at 1 — a contact form names a switchboard, and
+	 * fetching one to look for staff spends the money and returns nobody.
+	 */
+	weakestBand = 2,
 ): ReadonlyArray<string> => {
 	const seen = new Set<string>()
 	const ranked: Array<{ url: string; band: number }> = []
@@ -94,7 +123,7 @@ export const aboutPageCandidates = (
 		// null on an unparseable URL, and '/' for a bare host.)
 		if (path === null || path === '/') continue
 		const band = bandOf(path)
-		if (band === 3) continue
+		if (band > weakestBand) continue
 		// Drop the fragment so "/team" and "/team#ceo" aren't both fetched.
 		const url = link.split('#')[0] ?? link
 		if (seen.has(url)) continue

--- a/packages/research/src/application/about-pages.ts
+++ b/packages/research/src/application/about-pages.ts
@@ -11,7 +11,7 @@
  * over a bare contact form.
  */
 
-import { domainHost } from './entity-guard'
+import { DISTINCTIVE_NAME_LENGTH, domainHost } from './entity-guard'
 import { pathOf } from './source-key'
 
 // Path fragments that mark a page worth fetching, in three bands by what it usually
@@ -83,13 +83,35 @@ const NON_PAGE_SEGMENTS = new Set([
 const segmentNames = (segment: string, words: ReadonlySet<string>): boolean =>
 	segment.split(/[^a-z0-9]+/).some(word => word !== '' && words.has(word))
 
+// A page the company named after itself. Every word long enough to carry a name
+// has to be one of the company's own, so "/ca/er-enginy" is ER Enginy talking
+// about itself while "/referencies/nau-industrial-a-girona" is a project of its
+// own that happens to sit on the same site. Short words are passed over, because
+// a name breaks into them — "er" in ER Enginy, "de" in anything Spanish.
+const namedAfterTheCompany = (
+	path: string,
+	ownWords: ReadonlySet<string>,
+): boolean => {
+	if (ownWords.size === 0) return false
+	return path
+		.split('/')
+		.filter(Boolean)
+		.some(segment => {
+			const words = segment
+				.split(/[^a-z0-9]+/)
+				.filter(word => word.length >= DISTINCTIVE_NAME_LENGTH)
+			return words.length > 0 && words.every(word => ownWords.has(word))
+		})
+}
+
 // Which band a path falls in, or 3 (not a candidate) when no hint matches or it sits
 // in a section that only ever talks about other things.
-const bandOf = (path: string): number => {
+const bandOf = (path: string, ownWords: ReadonlySet<string>): number => {
 	if (path.split('/').some(segment => segmentNames(segment, NON_PAGE_SEGMENTS)))
 		return 3
 	if (TEAM_HINTS.some(hint => path.includes(hint))) return 0
 	if (ABOUT_HINTS.some(hint => path.includes(hint))) return 1
+	if (namedAfterTheCompany(path, ownWords)) return 1
 	if (CONTACT_HINTS.some(hint => path.includes(hint))) return 2
 	return 3
 }
@@ -103,15 +125,27 @@ export const aboutPageCandidates = (
 	links: ReadonlyArray<string>,
 	host: string,
 	max: number,
-	/**
-	 * The weakest kind of page worth taking: 0 a team page, 1 an about page, 2 a
-	 * contact page. A caller filling in a company's location takes all three,
-	 * because an address is on a contact page as often as anywhere. A caller after
-	 * the company's PEOPLE stops at 1 — a contact form names a switchboard, and
-	 * fetching one to look for staff spends the money and returns nobody.
-	 */
-	weakestBand = 2,
+	options: {
+		/**
+		 * The weakest kind of page worth taking: 0 a team page, 1 an about page, 2
+		 * a contact page. A caller filling in a company's location takes all three,
+		 * because an address is on a contact page as often as anywhere. A caller
+		 * after the company's PEOPLE stops at 1 — a contact form names a
+		 * switchboard, and fetching one to look for staff spends the money and
+		 * returns nobody.
+		 */
+		readonly weakestBand?: number
+		/**
+		 * The company's own distinctive words, when the caller knows them. A small
+		 * firm often names its about page after itself rather than "about" or
+		 * "nosaltres" — erenginy.com puts it at /ca/er-enginy — and no list of
+		 * words in any language will ever catch that.
+		 */
+		readonly ownWords?: ReadonlyArray<string>
+	} = {},
 ): ReadonlyArray<string> => {
+	const weakestBand = options.weakestBand ?? 2
+	const ownWords = new Set(options.ownWords ?? [])
 	const seen = new Set<string>()
 	const ranked: Array<{ url: string; band: number }> = []
 	for (const link of links) {
@@ -122,7 +156,7 @@ export const aboutPageCandidates = (
 		// Skip the homepage itself; it's already been fetched. (pathOf returns
 		// null on an unparseable URL, and '/' for a bare host.)
 		if (path === null || path === '/') continue
-		const band = bandOf(path)
+		const band = bandOf(path, ownWords)
 		if (band > weakestBand) continue
 		// Drop the fragment so "/team" and "/team#ceo" aren't both fetched.
 		const url = link.split('#')[0] ?? link

--- a/packages/research/src/application/budget.test.ts
+++ b/packages/research/src/application/budget.test.ts
@@ -322,6 +322,129 @@ describe('what a company may spend on paid calls in a month', () => {
 	})
 })
 
+// Every statement the budget issued, so a test can ask what it wrote rather than
+// what it returned. The ledger is the only place a refused charge shows up.
+const withRecordedSql = <A, E>(
+	body: (budget: Budget['Service']) => Effect.Effect<A, E, never>,
+): Promise<{
+	readonly result: A
+	readonly statements: ReadonlyArray<string>
+}> => {
+	const statements: string[] = []
+	const fakeSql = ((strings: ReadonlyArray<string>) => {
+		const text = strings.join(' ')
+		statements.push(text)
+		if (text.includes('organization_research_policy')) return Effect.succeed([])
+		if (text.includes('SUM(amount_cents)'))
+			return Effect.succeed([{ spent: 0 }])
+		if (text.includes('pg_advisory_xact_lock')) return Effect.succeed([])
+		return Effect.succeed([{ id: 'spend-1' }])
+	}) as unknown as SqlClient.SqlClient
+	Object.assign(fakeSql, {
+		withTransaction: <T, E2, R>(effect: Effect.Effect<T, E2, R>) => effect,
+	})
+	const layer = makeBudgetLayer({
+		organizationId: 'org-1',
+		userId: 'user-1',
+		researchId: 'run-1',
+		policy: new ResolvedPolicy({ ...POLICY }),
+		defaultCapCents: 2000,
+		systemCeiling: 10_000,
+	}).pipe(Layer.provide(Layer.succeed(SqlClient.SqlClient)(fakeSql)))
+	return Effect.runPromise(
+		Effect.gen(function* () {
+			const budget = yield* Budget
+			const result = yield* body(budget)
+			return { result, statements }
+		}).pipe(Effect.provide(layer), Effect.orDie),
+	)
+}
+
+const voidedCharges = (statements: ReadonlyArray<string>): number =>
+	statements.filter(
+		text =>
+			text.includes('UPDATE research_paid_spend') &&
+			text.includes('amount_cents = 0'),
+	).length
+
+describe('a vendor that refuses the work outright', () => {
+	const outOfCredit = Effect.fail(
+		new ProviderError({
+			provider: 'librebor',
+			message: 'registry lookup failed: HTTP 402',
+			recoverable: false,
+			quotaExhausted: true,
+		}),
+	)
+
+	describe('when it says it has no credit left', () => {
+		it('should take the charge back off the bill', async () => {
+			// GIVEN a register lookup the vendor turns away for want of credit
+			const { statements } = await withRecordedSql(budget =>
+				budget
+					.withPaidCharge(
+						'registry',
+						29,
+						'registry_lookup',
+						'k1',
+					)(() => outOfCredit)
+					.pipe(Effect.ignore),
+			)
+
+			// THEN the money is taken off: a vendor that refused the work never
+			// billed for it, and a charge left standing eats the month's allowance
+			// and reads in the breakdown as a lookup that happened
+			expect(voidedCharges(statements)).toBe(1)
+		})
+	})
+
+	describe('when the call fails on the way home instead', () => {
+		it('should leave the charge standing', async () => {
+			// GIVEN a call that reached the vendor and then broke
+			const { statements } = await withRecordedSql(budget =>
+				budget
+					.withPaidCharge(
+						'registry',
+						29,
+						'registry_lookup',
+						'k1',
+					)(() =>
+						Effect.fail(
+							new ProviderError({
+								provider: 'librebor',
+								message: 'socket hang up',
+								recoverable: true,
+							}),
+						),
+					)
+					.pipe(Effect.ignore),
+			)
+
+			// THEN nothing is taken back: the vendor may well have billed for a
+			// call that failed on the way back, and guessing otherwise invents a
+			// refund the vendor never gave
+			expect(voidedCharges(statements)).toBe(0)
+		})
+	})
+
+	describe('when the call succeeds', () => {
+		it('should leave the charge standing', async () => {
+			// GIVEN a lookup that worked
+			const { statements } = await withRecordedSql(budget =>
+				budget.withPaidCharge(
+					'registry',
+					29,
+					'registry_lookup',
+					'k1',
+				)(() => Effect.succeed('a record')),
+			)
+
+			// THEN the run is billed for it, as it should be
+			expect(voidedCharges(statements)).toBe(0)
+		})
+	})
+})
+
 describe('paying for a vendor call that then fails', () => {
 	describe('when the vendor call fails after the money was set aside', () => {
 		it('should give the run its allowance back', async () => {

--- a/packages/research/src/application/budget.ts
+++ b/packages/research/src/application/budget.ts
@@ -235,6 +235,32 @@ export const makeBudgetLayer = (config: BudgetConfig) =>
 					remaining: s.remaining + cents,
 				}))
 
+			// Take a charge back off the bill without taking the row away. The row
+			// records that the call was attempted, which is worth keeping — a
+			// breakdown that showed nothing at all could not tell a run that never
+			// tried from one turned away every time. Only the money goes.
+			const voidPaidCharge = (idempotencyKey: string) =>
+				sql`
+					UPDATE research_paid_spend
+					SET amount_cents = 0
+					WHERE organization_id = ${config.organizationId}
+					  AND idempotency_key = ${idempotencyKey}
+				`.pipe(
+					Effect.asVoid,
+					// Never let bookkeeping sink the run: the call already failed, and
+					// the caller is about to degrade on that. A charge left standing is
+					// reported rather than raised.
+					Effect.catchCause(cause =>
+						Effect.logWarning('budget.void_failed').pipe(
+							Effect.annotateLogs({
+								event: 'budget.void_failed',
+								idempotency_key: idempotencyKey,
+								cause: String(cause),
+							}),
+						),
+					),
+				)
+
 			// Named rather than written straight into the service object, so
 			// withPaidCharge below can pay through exactly the same path instead of
 			// keeping a second copy of the rules.
@@ -402,11 +428,20 @@ export const makeBudgetLayer = (config: BudgetConfig) =>
 										: Effect.andThen(
 												// A refusal is remembered, so the next call to
 												// this vendor is turned away rather than charged
-												// a second time.
+												// a second time — and the money is taken back off
+												// the bill, which a failure on the way home is not.
+												// A vendor that says outright it will not do the
+												// work has not billed for it, so a charge left
+												// standing is money the run never spent: it eats
+												// the month's allowance and reads in the breakdown
+												// as a lookup that happened.
 												causeIsQuotaRefusal(exit.cause)
-													? Ref.update(
-															refusedRef,
-															seen => new Set([...seen, provider]),
+													? Effect.andThen(
+															Ref.update(
+																refusedRef,
+																seen => new Set([...seen, provider]),
+															),
+															voidPaidCharge(idempotencyKey),
 														)
 													: Effect.void,
 												releaseRunAllowance(cents),

--- a/packages/research/src/application/contact-entity-guard.test.ts
+++ b/packages/research/src/application/contact-entity-guard.test.ts
@@ -220,6 +220,186 @@ describe('bindScanContactsToRows', () => {
 		})
 	})
 
+	describe('when a job title ends in a word companies are named after', () => {
+		it('should keep the employee rather than read the title as an employer', () => {
+			// GIVEN real staff whose titles end in Services, Solutions and Systems —
+			// the same words that end a company name
+			const findings = {
+				prospects: [
+					row('Talleres Vidal SL', [
+						person('Anna Serra', 'Anna Serra, Director of Client Services'),
+						person('Pau Mas', 'Pau Mas, Head of Technical Solutions'),
+						person('Ona Vila', 'Ona Vila, VP Business Systems'),
+					]),
+				],
+			}
+
+			// WHEN each row's people are held against that row
+			const result = bindScanContactsToRows(findings, 'prospects')
+
+			// THEN all three stay: none of those quotes names another employer
+			expect(result.dropped).toBe(0)
+			expect(contactsOn(result.findings, 0)).toHaveLength(3)
+		})
+	})
+
+	describe('when a stranger works for another firm in the same trade', () => {
+		it('should drop them, because a trade word tells two companies apart', () => {
+			// GIVEN a client quoted on the row's own page, whose company shares only
+			// the trade word — the shape of nearly every name in this market
+			const findings = {
+				prospects: [
+					row('Transportes Ribera SL', [
+						person(
+							'Marta Gomez',
+							'Marta Gomez, directora de Transportes Gomez SL, cliente nuestro.',
+						),
+					]),
+				],
+			}
+
+			// WHEN checked
+			const result = bindScanContactsToRows(findings, 'prospects')
+
+			// THEN the client goes: "Transportes" is what both are, not who either is
+			expect(result.dropped).toBe(1)
+			expect(contactsOn(result.findings, 0)).toEqual([])
+		})
+	})
+
+	describe('when a row is listed under a legal name its staff never use', () => {
+		it('should keep them, because the row gave the address they are quoted on', () => {
+			// GIVEN a registry-shaped row whose own team page calls the firm
+			// something else entirely, with only the website tying the two
+			const findings = {
+				prospects: [
+					{
+						name: 'Especialidades Geotecnicas e Ingenieria SL',
+						website: {
+							value: 'https://egein.com',
+							source_id: 'https://egein.com',
+						},
+						contacts: [
+							person('David Garrido', 'David Garrido, CEO at Egein Group'),
+						],
+					},
+				],
+			}
+
+			// WHEN checked
+			const result = bindScanContactsToRows(findings, 'prospects')
+
+			// THEN the CEO stays on his own company's row
+			expect(result.dropped).toBe(0)
+			expect(contactsOn(result.findings, 0)).toHaveLength(1)
+		})
+	})
+
+	describe('when nothing is left saying where a person was read', () => {
+		it('should drop them and count it apart from a misfiling', () => {
+			// GIVEN one person the citation guard emptied and one it left alone
+			const findings = {
+				prospects: [
+					row('Talleres Vidal SL', [
+						{ name: 'Ghost Name', citations: [] },
+						person('Anna Serra', 'Anna Serra, Gerent'),
+					]),
+				],
+			}
+
+			// WHEN checked
+			const result = bindScanContactsToRows(findings, 'prospects')
+
+			// THEN the unsourced one goes, under its own count
+			expect(result.droppedUncited).toBe(1)
+			expect(result.dropped).toBe(0)
+			expect(contactsOn(result.findings, 0)).toHaveLength(1)
+		})
+	})
+
+	describe('when the employer follows a comma or opens the sentence', () => {
+		it('should still read it as an employer', () => {
+			// GIVEN the two shapes press and testimonial copy actually use, neither
+			// of which puts a word in front placing anybody anywhere
+			const findings = {
+				prospects: [
+					row('Talleres Vidal SL', [
+						person(
+							'Mark Riskowitz',
+							'Mark Riskowitz, VP of Operations, Caraway Logistics',
+						),
+					]),
+					row('Talleres Vidal SL', [
+						person(
+							'Andrew Smith',
+							'Caraway Logistics promotes Andrew Smith to SVP',
+						),
+					]),
+				],
+			}
+
+			// WHEN each row's people are held against that row
+			const result = bindScanContactsToRows(findings, 'prospects')
+
+			// THEN both go: asking every quote for a placing word lost exactly these
+			expect(result.dropped).toBe(2)
+		})
+	})
+
+	describe('when a row is named after nothing but its trade', () => {
+		it('should keep its own staff and still refuse an unsourced one', () => {
+			// GIVEN a company whose every word is the trade, with an address of its
+			// own — so the check runs, but has no word to decide with
+			const findings = {
+				prospects: [
+					{
+						name: 'Transportes y Logistica SL',
+						website: {
+							value: 'https://transportesylogistica.es',
+							source_id: 'https://transportesylogistica.es',
+						},
+						contacts: [
+							person(
+								'Juan Perez',
+								'Juan Perez, Gerente de Transportes y Logistica SL',
+							),
+							{ name: 'Ghost Name', citations: [] },
+						],
+					},
+				],
+			}
+
+			// WHEN checked
+			const result = bindScanContactsToRows(findings, 'prospects')
+
+			// THEN the gerente stays — nothing here tells one haulier from another —
+			// while the one with no evidence at all still goes
+			expect(result.dropped).toBe(0)
+			expect(result.droppedUncited).toBe(1)
+			expect(
+				(contactsOn(result.findings, 0) as ReadonlyArray<{ name: string }>)[0]
+					?.name,
+			).toBe('Juan Perez')
+		})
+	})
+
+	describe('when a trade-only row has no address either', () => {
+		it('should still refuse a person with nothing behind them', () => {
+			// GIVEN a row that can decide nothing about whose staff anybody is
+			const findings = {
+				prospects: [
+					row('Transportes y Logistica SL', [{ name: 'Ghost', citations: [] }]),
+				],
+			}
+
+			// WHEN checked — THEN whether a person came with any evidence is not a
+			// question about the row, so it is asked anyway
+			expect(bindScanContactsToRows(findings, 'prospects').droppedUncited).toBe(
+				1,
+			)
+		})
+	})
+
 	describe('when the run is not a scan shape', () => {
 		it('should leave the findings untouched', () => {
 			// GIVEN no list field, which is what a run about one company passes

--- a/packages/research/src/application/contact-entity-guard.test.ts
+++ b/packages/research/src/application/contact-entity-guard.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { bindContactsToEntity } from './contact-entity-guard'
+import {
+	bindContactsToEntity,
+	bindScanContactsToRows,
+} from './contact-entity-guard'
 import { deriveEntityTargets } from './entity-guard'
 
 // The run is researching Circle Logistics; targets carry its name-core + domain.
@@ -137,6 +140,94 @@ describe('bindContactsToEntity', () => {
 
 			// THEN untouched
 			expect(contactsOf(result.findings)).toHaveLength(1)
+			expect(result.dropped).toBe(0)
+		})
+	})
+})
+
+describe('bindScanContactsToRows', () => {
+	const row = (name: string, contacts: ReadonlyArray<unknown>) => ({
+		name,
+		contacts,
+	})
+	const person = (name: string, quote: string) => ({
+		name,
+		citations: [{ quote, source_id: 'https://example.com', confidence: 90 }],
+	})
+	const contactsOn = (findings: unknown, at: number): unknown =>
+		(
+			(findings as { prospects: ReadonlyArray<Record<string, unknown>> })
+				.prospects[at] as Record<string, unknown>
+		)['contacts']
+
+	describe('when a person on one row is evidenced by another company', () => {
+		it('should drop them from that row and leave the rest alone', () => {
+			// GIVEN two companies, where the second row carries a director whose only
+			// quote names the first — the quiet mistake of filing somebody under the
+			// company listed above them
+			const findings = {
+				prospects: [
+					row('Calderería Sentmenat SL', [
+						person('Marta Puig', 'Marta Puig, Gerent at Sentmenat Group'),
+					]),
+					row('Talleres Vidal SL', [
+						person('Jordi Roca', 'Jordi Roca, Director at Sentmenat Group'),
+					]),
+				],
+			}
+
+			// WHEN each row's people are held against that row
+			const result = bindScanContactsToRows(findings, 'prospects')
+
+			// THEN the misfiled one goes and the rightly-filed one stays
+			expect(result.dropped).toBe(1)
+			expect(contactsOn(result.findings, 1)).toEqual([])
+			expect(
+				(contactsOn(result.findings, 0) as ReadonlyArray<{ name: string }>)[0]
+					?.name,
+			).toBe('Marta Puig')
+		})
+	})
+
+	describe('when the evidence names no company at all', () => {
+		it('should keep the person', () => {
+			// GIVEN a quote that reads the same for a real member of staff as for a
+			// stranger
+			const findings = {
+				prospects: [
+					row('Talleres Vidal SL', [
+						person('Anna Serra', 'Anna Serra, Gerent'),
+					]),
+				],
+			}
+
+			// WHEN checked — THEN they stay: losing real people is the worse mistake
+			expect(bindScanContactsToRows(findings, 'prospects').dropped).toBe(0)
+		})
+	})
+
+	describe('when the row name is too plain to decide anything', () => {
+		it('should keep everyone rather than half-check them', () => {
+			// GIVEN a company whose name has nothing distinctive to hold a quote
+			// against
+			const findings = {
+				prospects: [row('SL', [person('Pau Mas', 'Pau Mas at Other Group')])],
+			}
+
+			// WHEN checked — THEN nobody is dropped, because a name that answers to
+			// every quote cannot decide this one
+			expect(bindScanContactsToRows(findings, 'prospects').dropped).toBe(0)
+		})
+	})
+
+	describe('when the run is not a scan shape', () => {
+		it('should leave the findings untouched', () => {
+			// GIVEN no list field, which is what a run about one company passes
+			const findings = { contacts: [person('X', 'X at Y Group')] }
+
+			// WHEN checked — THEN it is the same object back, not a rebuilt copy
+			const result = bindScanContactsToRows(findings, undefined)
+			expect(result.findings).toBe(findings)
 			expect(result.dropped).toBe(0)
 		})
 	})

--- a/packages/research/src/application/contact-entity-guard.test.ts
+++ b/packages/research/src/application/contact-entity-guard.test.ts
@@ -150,9 +150,13 @@ describe('bindScanContactsToRows', () => {
 		name,
 		contacts,
 	})
-	const person = (name: string, quote: string) => ({
+	const person = (
+		name: string,
+		quote: string,
+		source = 'https://example.com',
+	) => ({
 		name,
-		citations: [{ quote, source_id: 'https://example.com', confidence: 90 }],
+		citations: [{ quote, source_id: source, confidence: 90 }],
 	})
 	const contactsOn = (findings: unknown, at: number): unknown =>
 		(
@@ -280,7 +284,11 @@ describe('bindScanContactsToRows', () => {
 							source_id: 'https://egein.com',
 						},
 						contacts: [
-							person('David Garrido', 'David Garrido, CEO at Egein Group'),
+							person(
+								'David Garrido',
+								'David Garrido, CEO at Egein Group',
+								'https://egein.com/equip',
+							),
 						],
 					},
 				],
@@ -362,6 +370,7 @@ describe('bindScanContactsToRows', () => {
 							person(
 								'Juan Perez',
 								'Juan Perez, Gerente de Transportes y Logistica SL',
+								'https://transportesylogistica.es/equip',
 							),
 							{ name: 'Ghost Name', citations: [] },
 						],
@@ -396,6 +405,178 @@ describe('bindScanContactsToRows', () => {
 			// question about the row, so it is asked anyway
 			expect(bindScanContactsToRows(findings, 'prospects').droppedUncited).toBe(
 				1,
+			)
+		})
+	})
+
+	describe('when only a directory about the company names a person', () => {
+		it('should refuse them, because a roster nobody owns goes stale', () => {
+			// GIVEN the shape a real scan returned: two people read off an
+			// aggregator's employee page, beside one read on the company's own site
+			const findings = {
+				prospects: [
+					{
+						name: 'Serxar',
+						website: {
+							value: 'https://www.serxar.com/',
+							source_id: 'https://www.serxar.com/',
+						},
+						contacts: [
+							person(
+								'Gerard Batlle',
+								'Gerard Batlle, Adjunto Direccion',
+								'https://rocketreach.co/serxar-sau-employees',
+							),
+							person(
+								'Anna Martinez',
+								"Anna Martinez, Cap d'Obra",
+								'https://rocketreach.co/serxar-sau-employees',
+							),
+							person(
+								'Marta Roca',
+								'Marta Roca, Gerent',
+								'https://www.serxar.com/en/about-us',
+							),
+						],
+					},
+				],
+			}
+
+			// WHEN checked
+			const result = bindScanContactsToRows(findings, 'prospects')
+
+			// THEN only the one the company itself names survives
+			expect(result.droppedOffSite).toBe(2)
+			expect(
+				(contactsOn(result.findings, 0) as ReadonlyArray<{ name: string }>).map(
+					c => c.name,
+				),
+			).toEqual(['Marta Roca'])
+		})
+	})
+
+	describe('when a row gave no address of its own', () => {
+		it('should keep a person read anywhere, having no way to tell', () => {
+			// GIVEN a company with no website on the row, so nothing separates its
+			// own pages from a page about it
+			const findings = {
+				prospects: [
+					row('Talleres Vidal SL', [
+						person(
+							'Marta Roca',
+							'Marta Roca, Gerent',
+							'https://rocketreach.co/talleres-vidal',
+						),
+					]),
+				],
+			}
+
+			// WHEN checked — THEN nobody goes: a rule that cannot tell the two
+			// apart must not act as though it can
+			expect(bindScanContactsToRows(findings, 'prospects').droppedOffSite).toBe(
+				0,
+			)
+		})
+	})
+
+	describe('when a title appears on no page the run read', () => {
+		it('should take the title and keep the person', () => {
+			// GIVEN the shape a real scan returned, where the model wrote its own
+			// uncertainty into the title rather than leaving it out
+			const findings = {
+				prospects: [
+					row('Bellmas Enginyers SL', [
+						{
+							name: 'Laura Bellmas',
+							role: 'Director/a (assumptiu – la pagina no indica el titol exacte)',
+							citations: [
+								{
+									quote: 'Laura Bellmas',
+									source_id: 'https://example.com',
+									confidence: 90,
+								},
+							],
+						},
+					]),
+				],
+			}
+
+			// WHEN checked against the pages the run actually read
+			const result = bindScanContactsToRows(
+				findings,
+				'prospects',
+				'Bellmas Enginyers Associats. Laura Bellmas. Contacte.',
+			)
+
+			// THEN she stays and the invented title goes: a made-up title is worse
+			// than none, because it is what somebody opens a call with
+			expect(result.droppedTitles).toBe(1)
+			const kept = contactsOn(result.findings, 0) as ReadonlyArray<
+				Record<string, unknown>
+			>
+			expect(kept).toHaveLength(1)
+			expect(kept[0]?.['name']).toBe('Laura Bellmas')
+			expect(kept[0]?.['role']).toBeUndefined()
+		})
+	})
+
+	describe('when a title is written on a page the run read', () => {
+		it('should keep it', () => {
+			// GIVEN a title copied verbatim off the team page
+			const findings = {
+				prospects: [
+					row('Egein', [
+						{
+							name: 'David Garrido',
+							role: 'CEO - Enginyer Industrial',
+							citations: [
+								{
+									quote: 'David Garrido',
+									source_id: 'https://example.com',
+									confidence: 90,
+								},
+							],
+						},
+					]),
+				],
+			}
+
+			// WHEN checked against a corpus that states it
+			const result = bindScanContactsToRows(
+				findings,
+				'prospects',
+				'David Garrido CEO - Enginyer Industrial Mariona Garrido CFO',
+			)
+
+			// THEN nothing is taken away
+			expect(result.droppedTitles).toBe(0)
+		})
+	})
+
+	describe('when the run read no pages at all', () => {
+		it('should leave every title alone rather than judge against nothing', () => {
+			// GIVEN no corpus to check against
+			const findings = {
+				prospects: [
+					row('Egein', [
+						{
+							name: 'David Garrido',
+							role: 'CEO',
+							citations: [
+								{
+									quote: 'x',
+									source_id: 'https://example.com',
+									confidence: 90,
+								},
+							],
+						},
+					]),
+				],
+			}
+
+			// WHEN checked with nothing behind it — THEN the title stays
+			expect(bindScanContactsToRows(findings, 'prospects').droppedTitles).toBe(
+				0,
 			)
 		})
 	})

--- a/packages/research/src/application/contact-entity-guard.ts
+++ b/packages/research/src/application/contact-entity-guard.ts
@@ -17,7 +17,12 @@
  * the two mistakes.
  */
 
-import { classifyEntityMatch, type EntityTargets } from './entity-guard'
+import {
+	classifyEntityMatch,
+	DISTINCTIVE_NAME_LENGTH,
+	type EntityTargets,
+	nameCoreTokens,
+} from './entity-guard'
 
 // A proper name (one to five capitalised words) directly followed by a company
 // marker — the shape of "<Company> Inc" / "Caraway Logistics". The markers include
@@ -100,4 +105,80 @@ export const bindContactsToEntity = (
 		findings: { ...(findings as object), contacts: kept },
 		dropped,
 	}
+}
+
+// The words in a company's name that could tell it from another one — its own
+// words, with the trade and the legal form taken off, and anything too short to
+// carry a name on its own.
+const distinctiveWordsOf = (name: string): ReadonlySet<string> =>
+	new Set(
+		nameCoreTokens(name).filter(word => word.length >= DISTINCTIVE_NAME_LENGTH),
+	)
+
+/**
+ * The same check for a search that returns many companies, each carrying the
+ * people its own pages named.
+ *
+ * The run has no one company to hold a person against — every row is a different
+ * one — so each row is checked against itself: a person kept on a row must not be
+ * evidenced only by a quote naming somebody else. Without it the likeliest
+ * mistake is the quiet one, where a director read on one company's page is filed
+ * under the company listed above it.
+ *
+ * A row whose own name is too short or too plain to tell companies apart keeps
+ * everyone. Half a check, applied confidently, drops real people.
+ */
+export const bindScanContactsToRows = (
+	findings: unknown,
+	listField: string | undefined,
+): ContactEntityResult => {
+	if (
+		listField === undefined ||
+		findings === null ||
+		typeof findings !== 'object' ||
+		Array.isArray(findings)
+	) {
+		return { findings, dropped: 0 }
+	}
+	const rows = (findings as Record<string, unknown>)[listField]
+	if (!Array.isArray(rows)) return { findings, dropped: 0 }
+
+	let dropped = 0
+	const keptRows = rows.map(row => {
+		if (row === null || typeof row !== 'object') return row
+		const record = row as Record<string, unknown>
+		const contacts = record['contacts']
+		if (!Array.isArray(contacts)) return row
+		const own = distinctiveWordsOf(
+			typeof record['name'] === 'string' ? record['name'] : '',
+		)
+		// A name with nothing distinctive in it would answer to any quote, so the
+		// check is skipped rather than run on a word that cannot decide anything.
+		if (own.size === 0) return row
+
+		const keptContacts = contacts.filter(contact => {
+			if (contact === null || typeof contact !== 'object') return true
+			const orgs = orgPhrasesIn(
+				contactQuotes(contact as Record<string, unknown>),
+			)
+			// No company named in the evidence reads the same for a real member of
+			// staff as for a stranger, and losing real people is the worse mistake.
+			if (orgs.length === 0) return true
+			// One word in common is enough, and prefix matching is not: a page says
+			// "Sentmenat Group" where the row reads "Calderería Sentmenat SL", and
+			// neither spells the other from its first letter.
+			const namesThisRow = orgs.some(org =>
+				[...distinctiveWordsOf(org)].some(word => own.has(word)),
+			)
+			if (!namesThisRow) dropped++
+			return namesThisRow
+		})
+		return keptContacts.length === contacts.length
+			? row
+			: { ...record, contacts: keptContacts }
+	})
+
+	return dropped === 0
+		? { findings, dropped: 0 }
+		: { findings: { ...(findings as object), [listField]: keptRows }, dropped }
 }

--- a/packages/research/src/application/contact-entity-guard.ts
+++ b/packages/research/src/application/contact-entity-guard.ts
@@ -19,13 +19,14 @@
 
 import {
 	classifyEntityMatch,
-	distinctiveWords,
+	deriveEntityTargets,
 	domainHost,
 	type EntityTargets,
-	hostLabel,
-	labelSpellsOneOf,
+	namesNobodyInParticular,
 } from './entity-guard'
 import { isValueWrapper, unwrapValue } from './guard-shapes'
+import { isInCorpus } from './scalar-field-guard'
+import { isFirstPartyHost } from './source-tier-guard'
 
 // A proper name (one to five capitalised words) directly followed by a company
 // marker — the shape of "<Company> Inc" / "Caraway Logistics". The markers include
@@ -107,6 +108,10 @@ export interface ContactEntityResult {
 	readonly dropped: number
 	/** Contacts dropped because nothing was left saying where they were read. */
 	readonly droppedUncited: number
+	/** Contacts dropped because only a directory about the company named them. */
+	readonly droppedOffSite: number
+	/** Titles removed because the pages the run read never say them. */
+	readonly droppedTitles: number
 }
 
 /**
@@ -123,11 +128,23 @@ export const bindContactsToEntity = (
 		typeof findings !== 'object' ||
 		Array.isArray(findings)
 	) {
-		return { findings, dropped: 0, droppedUncited: 0 }
+		return {
+			findings,
+			dropped: 0,
+			droppedUncited: 0,
+			droppedOffSite: 0,
+			droppedTitles: 0,
+		}
 	}
 	const contacts = (findings as { contacts?: unknown }).contacts
 	if (!Array.isArray(contacts))
-		return { findings, dropped: 0, droppedUncited: 0 }
+		return {
+			findings,
+			dropped: 0,
+			droppedUncited: 0,
+			droppedOffSite: 0,
+			droppedTitles: 0,
+		}
 
 	let dropped = 0
 	const kept = contacts.filter(contact => {
@@ -146,35 +163,42 @@ export const bindContactsToEntity = (
 	return {
 		findings: { ...(findings as object), contacts: kept },
 		dropped,
-		// Never any here: a run about one company has a step of its own for a
-		// person with no source to their name, and it runs later in the chain.
+		// Never any here: a run about one company has steps of its own for a person
+		// with no source to their name and for a title nothing supports, and they
+		// run later in the chain.
 		droppedUncited: 0,
+		droppedOffSite: 0,
+		droppedTitles: 0,
 	}
 }
 
-// The words in a company's name that could tell it from another one, read with
-// the shared `distinctiveWords`, which takes off the legal form AND the trade:
-// keeping the trade word let "Transportes Ribera" answer to a quote about
-// "Transportes Gomez", and in a market where most firms are Transportes-something
-// that is nearly every row.
-const distinctiveWordsOf = (name: string): ReadonlySet<string> =>
-	new Set(distinctiveWords(name))
-
-// The word a row's own web address is registered under — "egein" for
-// https://egein.com. A row's people are quoted on that site under whatever the
-// company calls itself day to day, which is often not the name the row was
-// listed under: "Especialidades Geotecnicas e Ingenieria SL" shares no word with
-// "EGEIN Group", and only egein.com says they are the same firm.
-const siteLabelOf = (row: Record<string, unknown>): string => {
+/**
+ * A row read as the thing a guard checks against — the same shape a run about one
+ * company builds for its subject, from the only two things a row knows about
+ * itself: what it is called and the address it gave.
+ *
+ * This is what lets a search reuse the checks written for a single company rather
+ * than keep a second copy of each. Null when the row says nothing distinctive
+ * enough to tell it from any other company on the list.
+ */
+const rowTargets = (row: Record<string, unknown>): EntityTargets | null => {
 	const website = row['website']
 	const address = isValueWrapper(website)
 		? unwrapValue(website)
 		: typeof website === 'string'
 			? website
 			: undefined
-	if (typeof address !== 'string') return ''
-	const host = domainHost(address)
-	return host === undefined ? '' : hostLabel(host)
+	return deriveEntityTargets({
+		schemaName: 'company_enrichment_v1',
+		query: '',
+		subjects: [
+			{
+				table: 'companies',
+				name: typeof row['name'] === 'string' ? row['name'] : undefined,
+				website: typeof address === 'string' ? address : undefined,
+			},
+		],
+	}).targets
 }
 
 /**
@@ -193,84 +217,141 @@ const siteLabelOf = (row: Record<string, unknown>): string => {
 export const bindScanContactsToRows = (
 	findings: unknown,
 	listField: string | undefined,
+	corpus = '',
 ): ContactEntityResult => {
+	const nothingToDo = {
+		findings,
+		dropped: 0,
+		droppedUncited: 0,
+		droppedOffSite: 0,
+		droppedTitles: 0,
+	}
 	if (
 		listField === undefined ||
 		findings === null ||
 		typeof findings !== 'object' ||
 		Array.isArray(findings)
 	) {
-		return { findings, dropped: 0, droppedUncited: 0 }
+		return nothingToDo
 	}
 	const rows = (findings as Record<string, unknown>)[listField]
-	if (!Array.isArray(rows)) return { findings, dropped: 0, droppedUncited: 0 }
+	if (!Array.isArray(rows)) return nothingToDo
+	const lowerCorpus = corpus.toLowerCase()
 
 	let dropped = 0
 	let droppedUncited = 0
+	let droppedOffSite = 0
+	let droppedTitles = 0
 	const keptRows = rows.map(row => {
 		if (row === null || typeof row !== 'object') return row
 		const record = row as Record<string, unknown>
 		const contacts = record['contacts']
 		if (!Array.isArray(contacts)) return row
-		const own = distinctiveWordsOf(
-			typeof record['name'] === 'string' ? record['name'] : '',
-		)
-		const siteLabel = siteLabelOf(record)
 		// A row with neither a name of its own nor an address cannot say whose
 		// staff anybody is — every quote would answer to it. Only that comparison
 		// is skipped, though: whether a person came with any evidence at all is
 		// not a question about the row, so it is still asked below.
-		const canDecide = own.size > 0 || siteLabel !== ''
+		const targets = rowTargets(record)
 
-		const keptContacts = contacts.filter(contact => {
-			if (contact === null || typeof contact !== 'object') return true
+		const keptContacts: unknown[] = []
+		for (const contact of contacts) {
+			if (contact === null || typeof contact !== 'object') {
+				keptContacts.push(contact)
+				continue
+			}
+			const held = contact as Record<string, unknown>
 			// Nothing says where this person was read. Either the model named a
 			// page the run never fetched — the citation guard, which runs before
 			// this, will have just taken it away — or it named none at all. A run
 			// about one company refuses such a person; a search returning fifty
 			// has fifty times the reason to.
-			const citations = (contact as Record<string, unknown>)['citations']
+			const citations = held['citations']
 			if (!Array.isArray(citations) || citations.length === 0) {
 				droppedUncited++
-				return false
+				continue
 			}
-			if (!canDecide) return true
-			const orgs = orgPhrasesIn(
-				contactQuotes(contact as Record<string, unknown>),
-			)
+			if (targets === null) {
+				keptContacts.push(contact)
+				continue
+			}
+			// Only the company's own pages may name its people. A directory about
+			// the company is not the company saying so: its rosters are scraped,
+			// years old, and list people who left — and a search reaching fifty
+			// firms will meet far more directories than team pages. Asked only of
+			// a row that gave an address, because without one there is nothing to
+			// tell a company's own site from a page about it.
+			if (targets.domains.length > 0) {
+				const hosts = citations.flatMap(citation => {
+					const id = (citation as Record<string, unknown>)['source_id']
+					const host = typeof id === 'string' ? domainHost(id) : undefined
+					return host === undefined ? [] : [host]
+				})
+				if (
+					hosts.length > 0 &&
+					!hosts.some(host => isFirstPartyHost(host, targets.domains))
+				) {
+					droppedOffSite++
+					continue
+				}
+			}
+			const orgs = orgPhrasesIn(contactQuotes(held))
 			// No company named in the evidence reads the same for a real member of
 			// staff as for a stranger, and losing real people is the worse mistake.
-			if (orgs.length === 0) return true
-			// One word in common is enough, and prefix matching is not: a page says
-			// "Sentmenat Group" where the row reads "Calderería Sentmenat SL", and
-			// neither spells the other from its first letter. Failing that, the
-			// row's own address answers for it, which is how a company listed under
-			// its legal name keeps the staff its trading name is quoted with.
-			const namesThisRow = orgs.some(org => {
-				const words = [...distinctiveWordsOf(org)]
-				// The quote names a company of nothing but its trade — "Transportes
-				// y Logistica SL". That reads the same for this row as for any
-				// other in the list, so it decides nothing, and a row whose own
-				// name is the same shape would otherwise throw out its own staff.
-				if (words.length === 0) return true
-				return (
-					words.some(word => own.has(word)) ||
-					(siteLabel !== '' && labelSpellsOneOf(siteLabel, words))
-				)
-			})
-			if (!namesThisRow) dropped++
-			return namesThisRow
-		})
-		return keptContacts.length === contacts.length
+			//
+			// A phrase of nothing but the trade — "Logistica SL" — names no company
+			// in particular either, so it cannot be evidence that this person
+			// belongs to a different one. Dropped from the reckoning rather than
+			// read as a stranger, which would take the gerente off a haulier named
+			// after what it does.
+			const named = orgs.filter(org => !namesNobodyInParticular(org))
+			// Any reading but "names nobody this row could be" keeps the person. A
+			// page saying "Sentmenat Group" where the row reads "Calderería
+			// Sentmenat SL" names one word of it and no more, which is as much as a
+			// company gets called in passing — and the row's own address answers
+			// for it too, which is how a company listed under its legal name keeps
+			// the staff its trading name is quoted with.
+			if (
+				named.length > 0 &&
+				!named.some(org => classifyEntityMatch(targets, org) !== 'absent')
+			) {
+				dropped++
+				continue
+			}
+			// The title is kept only if a page the run read actually says it. Asked
+			// because a model handed a person with no stated title writes one and
+			// says so in the same breath — "Director/a (the page does not give the
+			// exact title)" reached a real row — and a made-up title is worse than
+			// none: it is what somebody opens a call with.
+			const role = held['role']
+			if (
+				lowerCorpus !== '' &&
+				typeof role === 'string' &&
+				role.trim() !== '' &&
+				!isInCorpus(role, lowerCorpus)
+			) {
+				droppedTitles++
+				const { role: _removed, ...withoutRole } = held
+				keptContacts.push(withoutRole)
+				continue
+			}
+			keptContacts.push(contact)
+		}
+		return keptContacts.length === contacts.length &&
+			keptContacts.every((kept, i) => kept === contacts[i])
 			? row
 			: { ...record, contacts: keptContacts }
 	})
 
-	return dropped === 0 && droppedUncited === 0
-		? { findings, dropped: 0, droppedUncited: 0 }
+	return dropped === 0 &&
+		droppedUncited === 0 &&
+		droppedOffSite === 0 &&
+		droppedTitles === 0
+		? nothingToDo
 		: {
 				findings: { ...(findings as object), [listField]: keptRows },
 				dropped,
 				droppedUncited,
+				droppedOffSite,
+				droppedTitles,
 			}
 }

--- a/packages/research/src/application/contact-entity-guard.ts
+++ b/packages/research/src/application/contact-entity-guard.ts
@@ -19,10 +19,13 @@
 
 import {
 	classifyEntityMatch,
-	DISTINCTIVE_NAME_LENGTH,
+	distinctiveWords,
+	domainHost,
 	type EntityTargets,
-	nameCoreTokens,
+	hostLabel,
+	labelSpellsOneOf,
 } from './entity-guard'
+import { isValueWrapper, unwrapValue } from './guard-shapes'
 
 // A proper name (one to five capitalised words) directly followed by a company
 // marker — the shape of "<Company> Inc" / "Caraway Logistics". The markers include
@@ -30,8 +33,44 @@ import {
 const ORG_PHRASE =
 	/\b([A-Z][A-Za-z0-9&.'’-]*(?:\s+[A-Z][A-Za-z0-9&.'’-]*){0,4})\s+(Inc|LLC|Corp|Corporation|Ltd|Co|Company|Group|Holdings|Logistics|Transport|Transportation|Freight|Shipping|Solutions|Technologies|Systems|Industries|Services|Partners|GmbH|S\.?A|S\.?L|Srl|BV|AG|Pty|PLC)\b\.?/g
 
+// The markers that are as often the back half of a job title as the back half of
+// a company: "Director of Client Services", "Head of Technical Solutions", "VP
+// Business Systems". Every other marker in the pattern above names a company
+// wherever it turns up, and is read as written.
+const ALSO_TITLE_WORDS = new Set([
+	'Services',
+	'Solutions',
+	'Systems',
+	'Technologies',
+	'Partners',
+	'Industries',
+])
+
+// Words that put a person AT an organisation, so what follows one is an employer
+// and not the rest of what they are called.
+const WORKS_AT = /(?:\bat|\bfrom|\bwith)\s+$/i
+
+/**
+ * The companies a quote names.
+ *
+ * Every phrase counts but one shape: a marker that doubles as half a job title,
+ * with nothing before it placing anybody at a company. Counting those too read
+ * "Director of Client Services" as a firm called Client Services and threw a
+ * real employee off her own company's row.
+ *
+ * Deliberately no wider than that. Asking every phrase for a word that places
+ * somebody first lost the commonest shapes there are — "Mark Riskowitz, VP of
+ * Operations, Caraway Logistics" and "Caraway Logistics promotes Andrew Smith",
+ * where the employer just follows a comma or opens the sentence.
+ */
 const orgPhrasesIn = (text: string): ReadonlyArray<string> =>
-	[...text.matchAll(ORG_PHRASE)].map(m => `${m[1]} ${m[2]}`)
+	[...text.matchAll(ORG_PHRASE)]
+		.filter(
+			m =>
+				!ALSO_TITLE_WORDS.has((m[2] ?? '').replace(/\.$/, '')) ||
+				WORKS_AT.test(text.slice(0, m.index)),
+		)
+		.map(m => `${m[1]} ${m[2]}`)
 
 // Every quote a contact carries: its per-field sources (role/email/phone) and its
 // own citation list. These are what tie — or fail to tie — the person to the target.
@@ -66,6 +105,8 @@ export interface ContactEntityResult {
 	readonly findings: unknown
 	/** Contacts dropped because their evidence named only a different company. */
 	readonly dropped: number
+	/** Contacts dropped because nothing was left saying where they were read. */
+	readonly droppedUncited: number
 }
 
 /**
@@ -82,10 +123,11 @@ export const bindContactsToEntity = (
 		typeof findings !== 'object' ||
 		Array.isArray(findings)
 	) {
-		return { findings, dropped: 0 }
+		return { findings, dropped: 0, droppedUncited: 0 }
 	}
 	const contacts = (findings as { contacts?: unknown }).contacts
-	if (!Array.isArray(contacts)) return { findings, dropped: 0 }
+	if (!Array.isArray(contacts))
+		return { findings, dropped: 0, droppedUncited: 0 }
 
 	let dropped = 0
 	const kept = contacts.filter(contact => {
@@ -104,16 +146,36 @@ export const bindContactsToEntity = (
 	return {
 		findings: { ...(findings as object), contacts: kept },
 		dropped,
+		// Never any here: a run about one company has a step of its own for a
+		// person with no source to their name, and it runs later in the chain.
+		droppedUncited: 0,
 	}
 }
 
-// The words in a company's name that could tell it from another one — its own
-// words, with the trade and the legal form taken off, and anything too short to
-// carry a name on its own.
+// The words in a company's name that could tell it from another one, read with
+// the shared `distinctiveWords`, which takes off the legal form AND the trade:
+// keeping the trade word let "Transportes Ribera" answer to a quote about
+// "Transportes Gomez", and in a market where most firms are Transportes-something
+// that is nearly every row.
 const distinctiveWordsOf = (name: string): ReadonlySet<string> =>
-	new Set(
-		nameCoreTokens(name).filter(word => word.length >= DISTINCTIVE_NAME_LENGTH),
-	)
+	new Set(distinctiveWords(name))
+
+// The word a row's own web address is registered under — "egein" for
+// https://egein.com. A row's people are quoted on that site under whatever the
+// company calls itself day to day, which is often not the name the row was
+// listed under: "Especialidades Geotecnicas e Ingenieria SL" shares no word with
+// "EGEIN Group", and only egein.com says they are the same firm.
+const siteLabelOf = (row: Record<string, unknown>): string => {
+	const website = row['website']
+	const address = isValueWrapper(website)
+		? unwrapValue(website)
+		: typeof website === 'string'
+			? website
+			: undefined
+	if (typeof address !== 'string') return ''
+	const host = domainHost(address)
+	return host === undefined ? '' : hostLabel(host)
+}
 
 /**
  * The same check for a search that returns many companies, each carrying the
@@ -138,12 +200,13 @@ export const bindScanContactsToRows = (
 		typeof findings !== 'object' ||
 		Array.isArray(findings)
 	) {
-		return { findings, dropped: 0 }
+		return { findings, dropped: 0, droppedUncited: 0 }
 	}
 	const rows = (findings as Record<string, unknown>)[listField]
-	if (!Array.isArray(rows)) return { findings, dropped: 0 }
+	if (!Array.isArray(rows)) return { findings, dropped: 0, droppedUncited: 0 }
 
 	let dropped = 0
+	let droppedUncited = 0
 	const keptRows = rows.map(row => {
 		if (row === null || typeof row !== 'object') return row
 		const record = row as Record<string, unknown>
@@ -152,12 +215,26 @@ export const bindScanContactsToRows = (
 		const own = distinctiveWordsOf(
 			typeof record['name'] === 'string' ? record['name'] : '',
 		)
-		// A name with nothing distinctive in it would answer to any quote, so the
-		// check is skipped rather than run on a word that cannot decide anything.
-		if (own.size === 0) return row
+		const siteLabel = siteLabelOf(record)
+		// A row with neither a name of its own nor an address cannot say whose
+		// staff anybody is — every quote would answer to it. Only that comparison
+		// is skipped, though: whether a person came with any evidence at all is
+		// not a question about the row, so it is still asked below.
+		const canDecide = own.size > 0 || siteLabel !== ''
 
 		const keptContacts = contacts.filter(contact => {
 			if (contact === null || typeof contact !== 'object') return true
+			// Nothing says where this person was read. Either the model named a
+			// page the run never fetched — the citation guard, which runs before
+			// this, will have just taken it away — or it named none at all. A run
+			// about one company refuses such a person; a search returning fifty
+			// has fifty times the reason to.
+			const citations = (contact as Record<string, unknown>)['citations']
+			if (!Array.isArray(citations) || citations.length === 0) {
+				droppedUncited++
+				return false
+			}
+			if (!canDecide) return true
 			const orgs = orgPhrasesIn(
 				contactQuotes(contact as Record<string, unknown>),
 			)
@@ -166,10 +243,21 @@ export const bindScanContactsToRows = (
 			if (orgs.length === 0) return true
 			// One word in common is enough, and prefix matching is not: a page says
 			// "Sentmenat Group" where the row reads "Calderería Sentmenat SL", and
-			// neither spells the other from its first letter.
-			const namesThisRow = orgs.some(org =>
-				[...distinctiveWordsOf(org)].some(word => own.has(word)),
-			)
+			// neither spells the other from its first letter. Failing that, the
+			// row's own address answers for it, which is how a company listed under
+			// its legal name keeps the staff its trading name is quoted with.
+			const namesThisRow = orgs.some(org => {
+				const words = [...distinctiveWordsOf(org)]
+				// The quote names a company of nothing but its trade — "Transportes
+				// y Logistica SL". That reads the same for this row as for any
+				// other in the list, so it decides nothing, and a row whose own
+				// name is the same shape would otherwise throw out its own staff.
+				if (words.length === 0) return true
+				return (
+					words.some(word => own.has(word)) ||
+					(siteLabel !== '' && labelSpellsOneOf(siteLabel, words))
+				)
+			})
 			if (!namesThisRow) dropped++
 			return namesThisRow
 		})
@@ -178,7 +266,11 @@ export const bindScanContactsToRows = (
 			: { ...record, contacts: keptContacts }
 	})
 
-	return dropped === 0
-		? { findings, dropped: 0 }
-		: { findings: { ...(findings as object), [listField]: keptRows }, dropped }
+	return dropped === 0 && droppedUncited === 0
+		? { findings, dropped: 0, droppedUncited: 0 }
+		: {
+				findings: { ...(findings as object), [listField]: keptRows },
+				dropped,
+				droppedUncited,
+			}
 }

--- a/packages/research/src/application/contacts-rescue.ts
+++ b/packages/research/src/application/contacts-rescue.ts
@@ -87,7 +87,7 @@ export const contactsRescuePrompt = (
 // the markets this actually runs in.
 export const normalizeContactName = (name: string): string => foldLabel(name)
 
-interface RawContact {
+export interface RawContact {
 	readonly name?: unknown
 	readonly role?: unknown
 	readonly email?: unknown

--- a/packages/research/src/application/contacts-rescue.ts
+++ b/packages/research/src/application/contacts-rescue.ts
@@ -98,6 +98,35 @@ export interface RawContact {
 const citationsArray = (c: RawContact): ReadonlyArray<unknown> =>
 	Array.isArray(c.citations) ? c.citations : []
 
+// The same page quoted twice is one citation. A person met in three gap rounds
+// otherwise arrives carrying the same line three times, which reads to whoever
+// opens the finding as three sources agreeing.
+const joinCitations = (
+	a: ReadonlyArray<unknown>,
+	b: ReadonlyArray<unknown>,
+): ReadonlyArray<unknown> => {
+	const seen = new Set<string>()
+	const out: unknown[] = []
+	for (const citation of [...a, ...b]) {
+		const key = JSON.stringify(citation)
+		if (seen.has(key)) continue
+		seen.add(key)
+		out.push(citation)
+	}
+	return out
+}
+
+// Only the details one of the two actually carried. Writing every key whether or
+// not it holds anything puts `role: undefined` on a row whose schema has no room
+// for it — and on a scan row, no room for `email` or `phone` at all.
+const addDetail = (
+	into: Record<string, unknown>,
+	key: string,
+	value: unknown,
+): void => {
+	if (value !== undefined) into[key] = value
+}
+
 export interface ContactsMergeResult {
 	readonly contacts: ReadonlyArray<RawContact>
 	/** People left out because they came with no name to key on. */
@@ -140,13 +169,15 @@ export const mergeContacts = (
 			order.push(key)
 			return
 		}
-		byKey.set(key, {
-			name: existing.name,
-			role: existing.role ?? c.role,
-			email: existing.email ?? c.email,
-			phone: existing.phone ?? c.phone,
-			citations: [...citationsArray(existing), ...citationsArray(c)],
-		})
+		const joined: Record<string, unknown> = { name: existing.name }
+		addDetail(joined, 'role', existing.role ?? c.role)
+		addDetail(joined, 'email', existing.email ?? c.email)
+		addDetail(joined, 'phone', existing.phone ?? c.phone)
+		joined['citations'] = joinCitations(
+			citationsArray(existing),
+			citationsArray(c),
+		)
+		byKey.set(key, joined as RawContact)
 	}
 
 	for (const c of broad) absorb(c)

--- a/packages/research/src/application/eval-outcome.test.ts
+++ b/packages/research/src/application/eval-outcome.test.ts
@@ -18,6 +18,35 @@ describe('outcomeFromRun', () => {
 		})
 	})
 
+	describe('when a search filed its people under each company it found', () => {
+		it('should count them, where reading only the top level found none', () => {
+			// GIVEN a company search whose people hang off the rows, which is the
+			// only place a search ever puts them
+			const outcome = outcomeFromRun({
+				status: 'succeeded',
+				schemaName: 'prospect_scan_v1',
+				findings: {
+					prospects: [
+						{
+							name: 'Egein',
+							contacts: [
+								{ name: 'David Garrido', role: 'CEO' },
+								{ name: 'Mariona Garrido' },
+							],
+						},
+						{ name: 'Talleres Vidal SL', contacts: [] },
+					],
+				},
+				fetchedUrls: [],
+			})
+
+			// THEN both are counted and the titled one is told apart — a search that
+			// named two hundred people and one that named none read alike before
+			expect(outcome.people.named).toBe(2)
+			expect(outcome.people.titled).toBe(1)
+		})
+	})
+
 	describe('when a scan removed organisations from its list', () => {
 		it('should read them back off the finished run', () => {
 			// GIVEN a stored run in the shape the pipeline actually writes: the

--- a/packages/research/src/application/eval-outcome.ts
+++ b/packages/research/src/application/eval-outcome.ts
@@ -24,7 +24,7 @@ import {
 	type TerminalStatus,
 } from './eval-scoring'
 import { isConfirmedRow } from './existence-verdict'
-import { contactFill, enrichmentFill } from './extraction-fill'
+import { contactFill, contactsOf, enrichmentFill } from './extraction-fill'
 import { unwrapValue } from './guard-shapes'
 import { isSearchStopped, type SearchStopped } from './search-stopped'
 import { hostOf } from './source-key'
@@ -135,20 +135,14 @@ export const outcomeFromRun = (input: {
 	// title it found or null — so the scorer can measure how many known contacts
 	// came back with a title.
 	const contacts: Array<{ name: string; role: string | null }> = []
-	const rawContacts =
-		findings !== null && typeof findings === 'object'
-			? (findings as { contacts?: unknown }).contacts
-			: undefined
-	if (Array.isArray(rawContacts)) {
-		for (const contact of rawContacts) {
-			if (contact === null || typeof contact !== 'object') continue
-			const name = (contact as { name?: unknown }).name
-			if (typeof name !== 'string' || name.trim() === '') continue
-			contacts.push({
-				name,
-				role: readFieldValue((contact as { role?: unknown }).role),
-			})
-		}
+	for (const contact of contactsOf(findings)) {
+		if (contact === null || typeof contact !== 'object') continue
+		const name = (contact as { name?: unknown }).name
+		if (typeof name !== 'string' || name.trim() === '') continue
+		contacts.push({
+			name,
+			role: readFieldValue((contact as { role?: unknown }).role),
+		})
 	}
 
 	const reachedDomains: string[] = []
@@ -242,14 +236,17 @@ export const outcomeFromRun = (input: {
 		// the shape the run answered in, not whether the findings happen to carry a
 		// profile: a run that was asked and came back with nothing has no block either,
 		// and dropping it would lift the average by hiding the worst runs.
+		// Counted for every shape, by the same reader the run's own telemetry uses.
+		// A search files its people under each company it found rather than under
+		// the run, and a counter that knew only the second shape reported every
+		// search as having named nobody.
+		people: { named: people.named, titled: people.titled },
 		...(isScan
 			? {}
 			: {
 					profile: {
 						fieldsTotal: profileFill.total,
 						fieldsFilled: profileFill.filled,
-						contactsNamed: people.named,
-						contactsTitled: people.titled,
 					},
 				}),
 		...(input.usage !== undefined ? { usage: input.usage } : {}),

--- a/packages/research/src/application/eval-scoring-types.ts
+++ b/packages/research/src/application/eval-scoring-types.ts
@@ -154,14 +154,26 @@ export interface GoldenExpectation {
  * the same as one that returns a full picture — the opposite of what a rich
  * profile is worth.
  */
+/**
+ * The people a run named, whatever shape it answered in.
+ *
+ * Kept apart from `profile` because the two answer different questions: how full a
+ * profile came back applies only to a run asked for one, while a search names
+ * people too — they just hang off each company it found rather than off the run.
+ * Counting them inside the profile block reported every search as having found
+ * nobody, however many it named.
+ */
+export interface PeopleNamed {
+	/** People kept after the guards, whether or not a title came with them. */
+	readonly named: number
+	/** How many of those carry a title. */
+	readonly titled: number
+}
+
 export interface ProfileFullness {
 	/** Profile fields the shape asks for, and how many carry a real value. */
 	readonly fieldsTotal: number
 	readonly fieldsFilled: number
-	/** People named, whether or not a title came with them. */
-	readonly contactsNamed: number
-	/** Of those, how many carry a title — the ones worth writing to. */
-	readonly contactsTitled: number
 }
 
 /**
@@ -260,6 +272,8 @@ export interface RunOutcome {
 	readonly registryConfirmed?: boolean
 	/** How full the profile came back, across the whole output shape. */
 	readonly profile?: ProfileFullness
+	/** The people it named, counted for a search as well as a profile. */
+	readonly people: PeopleNamed
 }
 
 // What one run was billed, and what it consumed getting there — read back from
@@ -460,6 +474,8 @@ export interface RunScore {
 	readonly country?: string
 	/** How full the profile came back, independent of the golden answers. */
 	readonly profile?: ProfileFullness
+	/** The people it named, independent of the shape it answered in. */
+	readonly people?: PeopleNamed
 	/**
 	 * Whether this row asked for a market and the run came back with nothing to
 	 * score at all — it failed, or it was cancelled, so it carries no `market`

--- a/packages/research/src/application/eval-scoring.test.ts
+++ b/packages/research/src/application/eval-scoring.test.ts
@@ -30,6 +30,7 @@ const outcome = (over: Partial<RunOutcome>): RunOutcome => ({
 	removed: [],
 	searchingStopped: null,
 	reportedCoverage: null,
+	people: { named: 0, titled: 0 },
 	...over,
 })
 
@@ -1526,20 +1527,12 @@ describe('summarizeScores', () => {
 			// GIVEN two runs, one that came back full and one nearly empty
 			const summary = summarizeScores([
 				score({
-					profile: {
-						fieldsTotal: 6,
-						fieldsFilled: 6,
-						contactsNamed: 4,
-						contactsTitled: 3,
-					},
+					profile: { fieldsTotal: 6, fieldsFilled: 6 },
+					people: { named: 4, titled: 3 },
 				}),
 				score({
-					profile: {
-						fieldsTotal: 6,
-						fieldsFilled: 2,
-						contactsNamed: 0,
-						contactsTitled: 0,
-					},
+					profile: { fieldsTotal: 6, fieldsFilled: 2 },
+					people: { named: 0, titled: 0 },
 				}),
 			])
 

--- a/packages/research/src/application/eval-scoring.ts
+++ b/packages/research/src/application/eval-scoring.ts
@@ -333,6 +333,7 @@ export const scoreRun = (
 		contactsExpected: expectedContacts.length,
 		contactsFound,
 		...(outcome.profile !== undefined ? { profile: outcome.profile } : {}),
+		people: outcome.people,
 		...(outcome.usage !== undefined ? { usage: outcome.usage } : {}),
 		...(market !== undefined ? { market } : {}),
 		...(expected.bucket !== undefined ? { bucket: expected.bucket } : {}),
@@ -397,6 +398,7 @@ export const summarizeScores = (
 	let lowConfidence = 0
 	let empty = 0
 	let runsWithProfile = 0
+	let runsWithPeople = 0
 	let profileFieldsTotal = 0
 	let totalFieldsFilled = 0
 	let totalContactsNamed = 0
@@ -467,6 +469,11 @@ export const summarizeScores = (
 		}
 		if (score.lowConfidence) lowConfidence++
 		if (score.empty) empty++
+		if (score.people !== undefined) {
+			runsWithPeople++
+			totalContactsNamed += score.people.named
+			totalContactsTitled += score.people.titled
+		}
 		if (score.profile !== undefined) {
 			runsWithProfile++
 			// Every run is measured against the same profile shape, so this is the
@@ -474,8 +481,6 @@ export const summarizeScores = (
 			// something to add up.
 			profileFieldsTotal = score.profile.fieldsTotal
 			totalFieldsFilled += score.profile.fieldsFilled
-			totalContactsNamed += score.profile.contactsNamed
-			totalContactsTitled += score.profile.contactsTitled
 		}
 		if (score.marketWentUnanswered) scansThatNeverAnswered++
 		if (score.market !== undefined) {
@@ -600,9 +605,9 @@ export const summarizeScores = (
 			runsWithProfile === 0 ? null : totalFieldsFilled / runsWithProfile,
 		profileFieldsTotal: runsWithProfile === 0 ? null : profileFieldsTotal,
 		contactsNamedPerRun:
-			runsWithProfile === 0 ? null : totalContactsNamed / runsWithProfile,
+			runsWithPeople === 0 ? null : totalContactsNamed / runsWithPeople,
 		contactsTitledPerRun:
-			runsWithProfile === 0 ? null : totalContactsTitled / runsWithProfile,
+			runsWithPeople === 0 ? null : totalContactsTitled / runsWithPeople,
 		costPerRun: runsWithUsage === 0 ? null : totalCostCents / runsWithUsage,
 		costPerGroundedRun:
 			groundedRunsWithUsage === 0

--- a/packages/research/src/application/extraction-fill.test.ts
+++ b/packages/research/src/application/extraction-fill.test.ts
@@ -147,6 +147,30 @@ describe('contactFill', () => {
 		})
 	})
 
+	describe("when the people hang off a search's rows", () => {
+		it('should count them, with a plainly-written title counted as a title', () => {
+			// GIVEN a company search, where each row carries the people its own pages
+			// named and the title is written plainly rather than paired with a page
+			const result = contactFill({
+				prospects: [
+					{
+						name: 'EGEIN',
+						contacts: [
+							{ name: 'David Garrido', role: 'CEO - Enginyer Industrial' },
+							{ name: 'Mariona Garrido', role: 'CFO' },
+						],
+					},
+					{ name: 'Talleres Vidal SL', contacts: [{ name: 'Anna Serra' }] },
+				],
+			})
+
+			// THEN all three count, and the two with a title are told apart —
+			// reading only the top level reported nothing for every scan ever run
+			expect(result.named).toBe(3)
+			expect(result.titled).toBe(2)
+		})
+	})
+
 	describe('when there are no contacts', () => {
 		it('should count zero rather than throwing', () => {
 			// GIVEN findings with no contacts array

--- a/packages/research/src/application/extraction-fill.ts
+++ b/packages/research/src/application/extraction-fill.ts
@@ -73,7 +73,7 @@ export const hasTitle = (contact: unknown): boolean => {
 // top, and a search returning many hangs each company's people off its own row.
 // Reading only the first reported nothing for every scan ever run, so a search
 // that named two hundred people and one that named none read the same.
-const contactsOf = (findings: unknown): ReadonlyArray<unknown> => {
+export const contactsOf = (findings: unknown): ReadonlyArray<unknown> => {
 	if (findings === null || typeof findings !== 'object') return []
 	const record = findings as Record<string, unknown>
 	const top = Array.isArray(record['contacts']) ? record['contacts'] : []

--- a/packages/research/src/application/extraction-fill.ts
+++ b/packages/research/src/application/extraction-fill.ts
@@ -60,15 +60,35 @@ export const enrichmentFill = (findings: unknown): EnrichmentFill => {
 export const hasTitle = (contact: unknown): boolean => {
 	if (contact === null || typeof contact !== 'object') return false
 	const role = (contact as { role?: unknown }).role
+	// A scan writes the title plainly; a run about one company pairs it with the
+	// page it was read on. Reading only the paired shape counted every titled
+	// person a search found as untitled.
+	if (typeof role === 'string') return role.trim() !== ''
 	if (role === null || typeof role !== 'object') return false
 	const value = (role as { value?: unknown }).value
 	return typeof value === 'string' && value.trim() !== ''
 }
 
+// Both places a pass can leave people: a run about one company files them at the
+// top, and a search returning many hangs each company's people off its own row.
+// Reading only the first reported nothing for every scan ever run, so a search
+// that named two hundred people and one that named none read the same.
 const contactsOf = (findings: unknown): ReadonlyArray<unknown> => {
 	if (findings === null || typeof findings !== 'object') return []
-	const contacts = (findings as { contacts?: unknown }).contacts
-	return Array.isArray(contacts) ? contacts : []
+	const record = findings as Record<string, unknown>
+	const top = Array.isArray(record['contacts']) ? record['contacts'] : []
+	const onRows = Object.values(record).flatMap(value =>
+		Array.isArray(value)
+			? value.flatMap(row =>
+					row !== null &&
+					typeof row === 'object' &&
+					Array.isArray((row as Record<string, unknown>)['contacts'])
+						? ((row as Record<string, unknown>)['contacts'] as unknown[])
+						: [],
+				)
+			: [],
+	)
+	return [...top, ...onRows]
 }
 
 const isNamed = (contact: unknown): boolean =>

--- a/packages/research/src/application/per-field-search.test.ts
+++ b/packages/research/src/application/per-field-search.test.ts
@@ -1636,3 +1636,58 @@ describe('roundChangedNothing', () => {
 		})
 	})
 })
+
+describe('the people on a company a wider read met again', () => {
+	const person = (name: string) => ({ name, citations: [] })
+	const row = (name: string, contacts: ReadonlyArray<unknown>) => ({
+		name,
+		website: { value: `https://${name.toLowerCase()}.example`, source_id: 'x' },
+		contacts,
+	})
+	const peopleOn = (findings: unknown): ReadonlyArray<{ name: string }> =>
+		(
+			(findings as { prospects: ReadonlyArray<Record<string, unknown>> })
+				.prospects[0] as Record<string, unknown>
+		)['contacts'] as ReadonlyArray<{ name: string }>
+
+	describe('when the later read names somebody the row did not have', () => {
+		it('should join them rather than leave the row as it was', () => {
+			// GIVEN a company already naming one director, met again on a page that
+			// names two more. Every other fact is one value, so a row that has one
+			// is answered — people are a list that is never finished.
+			const merged = mergePerFieldSearch(
+				{ prospects: [row('Vidal', [person('Anna Serra')])] },
+				{
+					prospects: [row('Vidal', [person('Jordi Roca'), person('Pau Mas')])],
+				},
+				'prospect_scan_v1',
+				noRunWords,
+			)
+
+			// WHEN folded — THEN the row holds all three, and the round reports that
+			// it gained people so the loop does not read it as having done nothing
+			expect(
+				peopleOn(merged.findings)
+					.map(p => p.name)
+					.sort(),
+			).toEqual(['Anna Serra', 'Jordi Roca', 'Pau Mas'])
+			expect(merged.contactsChanged).toBe(true)
+		})
+	})
+
+	describe('when the later read names only people already on the row', () => {
+		it('should report nothing gained', () => {
+			// GIVEN the same person read twice
+			const merged = mergePerFieldSearch(
+				{ prospects: [row('Vidal', [person('Anna Serra')])] },
+				{ prospects: [row('Vidal', [person('Anna Serra')])] },
+				'prospect_scan_v1',
+				noRunWords,
+			)
+
+			// WHEN folded — THEN the round is honest about having added nobody
+			expect(merged.contactsChanged).toBe(false)
+			expect(peopleOn(merged.findings)).toHaveLength(1)
+		})
+	})
+})

--- a/packages/research/src/application/per-field-search.test.ts
+++ b/packages/research/src/application/per-field-search.test.ts
@@ -1675,6 +1675,76 @@ describe('the people on a company a wider read met again', () => {
 		})
 	})
 
+	describe('when the row already holds an entry the model left nameless', () => {
+		it('should still take a person the later read names', () => {
+			// GIVEN a row holding one real person and one the model emitted without a
+			// name. The merge drops the nameless one, so the list comes back the same
+			// length with a different person in it — and counting by length reads that
+			// as nothing gained.
+			const merged = mergePerFieldSearch(
+				{
+					prospects: [
+						row('Vidal', [
+							person('Anna Serra'),
+							{ name: undefined, citations: [] },
+						]),
+					],
+				},
+				{ prospects: [row('Vidal', [person('Jordi Roca')])] },
+				'prospect_scan_v1',
+				noRunWords,
+			)
+
+			// WHEN folded — THEN the new person is on the row and the round says so
+			expect(peopleOn(merged.findings).map(p => p.name)).toContain('Jordi Roca')
+			expect(merged.contactsChanged).toBe(true)
+		})
+	})
+
+	describe('when the later read puts a title on somebody already named', () => {
+		it('should keep the title rather than call the round empty', () => {
+			// GIVEN a homepage that named the director and a team page, read a round
+			// later, that finally says what he does
+			const merged = mergePerFieldSearch(
+				{ prospects: [row('Vidal', [person('David Garrido')])] },
+				{
+					prospects: [
+						row('Vidal', [{ ...person('David Garrido'), role: 'CEO' }]),
+					],
+				},
+				'prospect_scan_v1',
+				noRunWords,
+			)
+
+			// WHEN folded — THEN the title is on the row, even though nobody is new
+			expect(peopleOn(merged.findings)).toHaveLength(1)
+			expect((peopleOn(merged.findings)[0] as { role?: string }).role).toBe(
+				'CEO',
+			)
+			expect(merged.contactsChanged).toBe(true)
+		})
+	})
+
+	describe('when the later read carries a blank title', () => {
+		it('should report nothing gained rather than buy another round', () => {
+			// GIVEN a read that returns the same person with a role of blank spaces
+			const merged = mergePerFieldSearch(
+				{ prospects: [row('Vidal', [person('David Garrido')])] },
+				{
+					prospects: [
+						row('Vidal', [{ ...person('David Garrido'), role: '   ' }]),
+					],
+				},
+				'prospect_scan_v1',
+				noRunWords,
+			)
+
+			// WHEN folded — THEN nothing counts as gained: a title of blank spaces
+			// differs from no title by the letter of a comparison and nothing else
+			expect(merged.contactsChanged).toBe(false)
+		})
+	})
+
 	describe('when the later read names only people already on the row', () => {
 		it('should report nothing gained', () => {
 			// GIVEN the same person read twice

--- a/packages/research/src/application/per-field-search.ts
+++ b/packages/research/src/application/per-field-search.ts
@@ -20,7 +20,7 @@
  * any other.
  */
 
-import { mergeContacts } from './contacts-rescue'
+import { mergeContacts, type RawContact } from './contacts-rescue'
 import { discoveryResultField, isDiscoveryScan } from './discovery-scan'
 import { enrichmentFill } from './extraction-fill'
 import { isPlainObject, isValueWrapper, unwrapValue } from './guard-shapes'
@@ -74,6 +74,29 @@ export const scanRowFields = (schemaName: string): ReadonlyArray<string> =>
 // round that meets one has found the only way anybody has of reaching a company
 // with no site of its own, and a field left off this list is one whose value is
 // thrown away even when a round does turn it up.
+/**
+ * The people on a row after a wider read, or nothing when it found none the row
+ * did not already hold.
+ *
+ * Joined rather than filled in: every other fact on a row is one value, so a row
+ * that has it is answered. A row's people are a list that is never finished, and
+ * a company naming one director on its homepage and three more on a team page
+ * would otherwise keep only whichever page was read first.
+ */
+const unionRowContacts = (
+	held: unknown,
+	found: unknown,
+): { contacts: ReadonlyArray<unknown>; gained: number } | undefined => {
+	if (!Array.isArray(found) || found.length === 0) return undefined
+	const before = Array.isArray(held) ? held : []
+	const merged = mergeContacts(
+		before as ReadonlyArray<RawContact>,
+		found as ReadonlyArray<RawContact>,
+	)
+	const gained = merged.contacts.length - before.length
+	return gained > 0 ? { contacts: merged.contacts, gained } : undefined
+}
+
 const SCAN_ROW_FOLD_FIELDS_BY_SCHEMA: Record<string, ReadonlyArray<string>> = {
 	prospect_scan_v1: [
 		'website',
@@ -451,6 +474,7 @@ const mergeScanRows = (
 		}
 	}
 	let filled = 0
+	let gainedPeople = 0
 	const merged = known.map(row => {
 		const match = discoveryRowIdentityKeys(row, ownSiteHosts)
 			.map(key => foundByKey.get(key))
@@ -464,8 +488,16 @@ const mergeScanRows = (
 				filledHere++
 			}
 		}
+		// People are joined, not filled in. A row already naming one person reads
+		// as answered to every other field's test, so treating them the same way
+		// would let a company with a single name on file never gain a second.
+		const people = unionRowContacts(row['contacts'], match['contacts'])
+		if (people !== undefined) {
+			next['contacts'] = people.contacts
+			gainedPeople += people.gained
+		}
 		filled += filledHere
-		return filledHere === 0 ? row : next
+		return filledHere === 0 && people === undefined ? row : next
 	})
 	// Grows as companies are taken, so one re-extraction naming the same new
 	// company twice appends it once. A duplicate would not only read badly — the
@@ -495,11 +527,11 @@ const mergeScanRows = (
 		for (const key of keys) taken.add(key)
 		return true
 	})
-	if (filled === 0 && additions.length === 0) {
+	if (filled === 0 && gainedPeople === 0 && additions.length === 0) {
 		return {
 			findings,
 			filled: 0,
-			contactsChanged: false,
+			contactsChanged: gainedPeople > 0,
 			added: 0,
 			folded: joinedOnSite,
 		}
@@ -541,7 +573,7 @@ const mergeScanRows = (
 	return {
 		findings: settled.findings,
 		filled,
-		contactsChanged: false,
+		contactsChanged: gainedPeople > 0,
 		added:
 			before === undefined || after === undefined
 				? additions.length

--- a/packages/research/src/application/per-field-search.ts
+++ b/packages/research/src/application/per-field-search.ts
@@ -20,7 +20,11 @@
  * any other.
  */
 
-import { mergeContacts, type RawContact } from './contacts-rescue'
+import {
+	mergeContacts,
+	normalizeContactName,
+	type RawContact,
+} from './contacts-rescue'
 import { discoveryResultField, isDiscoveryScan } from './discovery-scan'
 import { enrichmentFill } from './extraction-fill'
 import { isPlainObject, isValueWrapper, unwrapValue } from './guard-shapes'
@@ -68,6 +72,24 @@ const SCAN_ROW_FIELDS_BY_SCHEMA: Record<string, ReadonlyArray<string>> = {
 export const scanRowFields = (schemaName: string): ReadonlyArray<string> =>
 	SCAN_ROW_FIELDS_BY_SCHEMA[schemaName] ?? []
 
+// What a later read can add to somebody a row already names.
+const DETAILS = ['role', 'email', 'phone'] as const
+
+// A detail is only a detail when it says something. A role of blank spaces
+// differs from nothing at all by the letter of a comparison and by nothing else,
+// and reading it as a gain writes it onto the row and buys another round.
+const detailKey = (value: unknown): string =>
+	typeof value === 'string' && value.trim() === ''
+		? 'null'
+		: JSON.stringify(value ?? null)
+
+const sameDetail = (
+	was: Record<string, unknown>,
+	now: RawContact,
+	key: string,
+): boolean =>
+	detailKey(was[key]) === detailKey((now as Record<string, unknown>)[key])
+
 // What a wider read is allowed to fill in on a company the list already holds.
 // Everything worth going out and searching for, plus what a run turns up without
 // being asked: a company's pages on the platforms are never searched for, but a
@@ -86,15 +108,42 @@ export const scanRowFields = (schemaName: string): ReadonlyArray<string> =>
 const unionRowContacts = (
 	held: unknown,
 	found: unknown,
-): { contacts: ReadonlyArray<unknown>; gained: number } | undefined => {
+): ReadonlyArray<unknown> | undefined => {
 	if (!Array.isArray(found) || found.length === 0) return undefined
 	const before = Array.isArray(held) ? held : []
 	const merged = mergeContacts(
 		before as ReadonlyArray<RawContact>,
 		found as ReadonlyArray<RawContact>,
 	)
-	const gained = merged.contacts.length - before.length
-	return gained > 0 ? { contacts: merged.contacts, gained } : undefined
+	// Counted by who is new, never by how much longer the list got. The merge
+	// drops an entry the model left nameless, so a row holding one of those
+	// alongside one real person comes back the same length with a different
+	// person in it — and a length test reads that as nothing gained and throws
+	// the new one away.
+	const heldByName = new Map(
+		before.flatMap(person =>
+			isPlainObject(person) && typeof person['name'] === 'string'
+				? ([[normalizeContactName(person['name']), person]] as const)
+				: [],
+		),
+	)
+	const gained = merged.contacts.filter(
+		person =>
+			typeof person.name === 'string' &&
+			!heldByName.has(normalizeContactName(person.name)),
+	).length
+	// A title put on somebody already named is worth the write too. The round
+	// that finally opens the team page usually finds the same director the
+	// homepage named, now with the job he does under him, and counting people
+	// alone hands that back unchanged.
+	const detailed = merged.contacts.some(person => {
+		if (typeof person.name !== 'string') return false
+		const was = heldByName.get(normalizeContactName(person.name))
+		return (
+			was !== undefined && !DETAILS.every(key => sameDetail(was, person, key))
+		)
+	})
+	return gained > 0 || detailed ? merged.contacts : undefined
 }
 
 const SCAN_ROW_FOLD_FIELDS_BY_SCHEMA: Record<string, ReadonlyArray<string>> = {
@@ -474,7 +523,7 @@ const mergeScanRows = (
 		}
 	}
 	let filled = 0
-	let gainedPeople = 0
+	let peopleBettered = false
 	const merged = known.map(row => {
 		const match = discoveryRowIdentityKeys(row, ownSiteHosts)
 			.map(key => foundByKey.get(key))
@@ -492,9 +541,12 @@ const mergeScanRows = (
 		// as answered to every other field's test, so treating them the same way
 		// would let a company with a single name on file never gain a second.
 		const people = unionRowContacts(row['contacts'], match['contacts'])
+		// A round can better a row without adding anybody to it — the team page
+		// that finally says what the director the homepage named actually does —
+		// so this says the row moved, not how many people it gained.
 		if (people !== undefined) {
-			next['contacts'] = people.contacts
-			gainedPeople += people.gained
+			next['contacts'] = people
+			peopleBettered = true
 		}
 		filled += filledHere
 		return filledHere === 0 && people === undefined ? row : next
@@ -527,11 +579,11 @@ const mergeScanRows = (
 		for (const key of keys) taken.add(key)
 		return true
 	})
-	if (filled === 0 && gainedPeople === 0 && additions.length === 0) {
+	if (filled === 0 && !peopleBettered && additions.length === 0) {
 		return {
 			findings,
 			filled: 0,
-			contactsChanged: gainedPeople > 0,
+			contactsChanged: false,
 			added: 0,
 			folded: joinedOnSite,
 		}
@@ -573,7 +625,7 @@ const mergeScanRows = (
 	return {
 		findings: settled.findings,
 		filled,
-		contactsChanged: gainedPeople > 0,
+		contactsChanged: peopleBettered,
 		added:
 			before === undefined || after === undefined
 				? additions.length

--- a/packages/research/src/application/prospect-dedupe-guard.ts
+++ b/packages/research/src/application/prospect-dedupe-guard.ts
@@ -93,6 +93,7 @@
  * survivor evidence gathered about somebody else.
  */
 
+import { mergeContacts, type RawContact } from './contacts-rescue'
 import {
 	collapse,
 	DISTINCTIVE_NAME_LENGTH,
@@ -572,6 +573,20 @@ const foldInto = (
 		if (value === undefined || value === null) continue
 		if (field === 'citations') {
 			merged['citations'] = mergeCitations(kept['citations'], value)
+			continue
+		}
+		// The people on both rows are the same company's people. Kept the way the
+		// citations above are: two spellings of one firm are usually two pages of
+		// it, and each names whoever it happened to list — so filling only where
+		// the surviving row was empty would throw away everyone on the second page
+		// of a company that already named one director.
+		if (field === 'contacts' && Array.isArray(value)) {
+			merged['contacts'] = mergeContacts(
+				Array.isArray(kept['contacts'])
+					? (kept['contacts'] as ReadonlyArray<RawContact>)
+					: [],
+				value as ReadonlyArray<RawContact>,
+			).contacts
 			continue
 		}
 		if (field === 'location' && alsoElsewhere) {

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -4006,9 +4006,15 @@ export class ResearchService extends Context.Service<ResearchService>()(
 												? bindScanContactsToRows(
 														findings,
 														discoveryResultField(schemaName),
+														evidenceCorpus,
 													)
 												: bindContactsToEntity(findings, entityTargets)
-											if (check.dropped > 0 || check.droppedUncited > 0) {
+											if (
+												check.dropped > 0 ||
+												check.droppedUncited > 0 ||
+												check.droppedOffSite > 0 ||
+												check.droppedTitles > 0
+											) {
 												yield* Effect.logWarning(
 													'research.contacts.wrong_entity',
 												).pipe(
@@ -4017,6 +4023,8 @@ export class ResearchService extends Context.Service<ResearchService>()(
 														research_id: researchId,
 														dropped: check.dropped,
 														dropped_uncited: check.droppedUncited,
+														dropped_off_site: check.droppedOffSite,
+														dropped_titles: check.droppedTitles,
 													}),
 												)
 											}

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -1491,12 +1491,17 @@ export const buildExtractionPrompt = (args: {
 		"Read ALL of the evidence to the end — every fetched page and every search result in the transcript — and report every fact it states; the evidence routinely states far more than a first pass returns. Report the industry, employee-count band, location, country, and the company's own operational software wherever the evidence states them — including on a third-party page rather than the company's own site.",
 		'',
 	]
-	// The breadth ask, addressed to whichever list this run's answer actually is.
-	// A scan is asked for companies and has no people list to fill; saying both
-	// would push it to invent one.
+	// The breadth ask, addressed to whichever list this run's answer actually is —
+	// and, either way, the ask for the people in it. A scan's people hang off each
+	// company rather than off the run, so it is told where they go; without that
+	// it reads the ask as a second list to fill and invents one.
 	if (args.discoveryScan) {
 		lines.push(DISCOVERY_BREADTH_DIRECTIVE, '')
 		lines.push(DISCOVERY_ORGANISATION_KIND_DIRECTIVE, '')
+		lines.push(
+			"Where the evidence names somebody as a company's own leader or employee — a titled person on its team page, a quoted founder, a signed author — put them in THAT company's `contacts`, with the exact job title the evidence gives them and the page you read them on. Under the company they work for, never the one listed beside them, and never in a list of their own. A company whose pages name its staff and comes back with an empty `contacts` is an incomplete row.",
+			'',
+		)
 		if (args.marksUnconfirmed) lines.push(DISCOVERY_UNCONFIRMED_DIRECTIVE, '')
 	} else {
 		lines.push(

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -3861,40 +3861,6 @@ export class ResearchService extends Context.Service<ResearchService>()(
 										}),
 								},
 								{
-									// Contact entity binding: drop a person whose quotes name only a
-									// different company (a client testimonial or a competitor's exec
-									// quoted on the target's own page), so the richer extraction
-									// can't present someone else's leader as this company's contact.
-									name: 'contact-entity',
-									run: findings =>
-										Effect.gen(function* () {
-											// Passes every person through when there are no keys: with
-											// nothing to hold a quote against, one naming another
-											// company cannot be told from one naming this company.
-											// Two shapes, two checks. A run about one company holds its
-											// people against that company; a search returning many holds
-											// each row's people against that row.
-											const check = isDiscoveryScan(schemaName)
-												? bindScanContactsToRows(
-														findings,
-														discoveryResultField(schemaName),
-													)
-												: bindContactsToEntity(findings, entityTargets)
-											if (check.dropped > 0) {
-												yield* Effect.logWarning(
-													'research.contacts.wrong_entity',
-												).pipe(
-													Effect.annotateLogs({
-														event: 'research.contacts.wrong_entity',
-														research_id: researchId,
-														dropped: check.dropped,
-													}),
-												)
-											}
-											return { findings: check.findings }
-										}),
-								},
-								{
 									// Scalar grounding: hold each per-field value to "grounded or
 									// absent". The citation guard has just removed fabricated
 									// sources, so a scalar left without one is dropped here rather
@@ -4013,6 +3979,48 @@ export class ResearchService extends Context.Service<ResearchService>()(
 														check.namedNobodyInParticular,
 												},
 											}
+										}),
+								},
+								{
+									// Contact entity binding: drop a person whose quotes name only a
+									// different company (a client testimonial or a competitor's exec
+									// quoted on the target's own page), so the richer extraction
+									// can't present someone else's leader as this company's contact.
+									//
+									// After the websites check above, because a search's rows are held
+									// against the address each one gave: a row still carrying somebody
+									// else's site would take that owner's staff as its own, and the
+									// check above is what takes such an address away. After the
+									// citation check too, so a person left with no source to their
+									// name has already lost it by the time this asks.
+									name: 'contact-entity',
+									run: findings =>
+										Effect.gen(function* () {
+											// Passes every person through when there are no keys: with
+											// nothing to hold a quote against, one naming another
+											// company cannot be told from one naming this company.
+											// Two shapes, two checks. A run about one company holds its
+											// people against that company; a search returning many holds
+											// each row's people against that row.
+											const check = isDiscoveryScan(schemaName)
+												? bindScanContactsToRows(
+														findings,
+														discoveryResultField(schemaName),
+													)
+												: bindContactsToEntity(findings, entityTargets)
+											if (check.dropped > 0 || check.droppedUncited > 0) {
+												yield* Effect.logWarning(
+													'research.contacts.wrong_entity',
+												).pipe(
+													Effect.annotateLogs({
+														event: 'research.contacts.wrong_entity',
+														research_id: researchId,
+														dropped: check.dropped,
+														dropped_uncited: check.droppedUncited,
+													}),
+												)
+											}
+											return { findings: check.findings }
 										}),
 								},
 								{

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -4894,14 +4894,20 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							// points at the guards, a low value everywhere at the model.
 							if (isEnrichmentRun) {
 								const keptFill = enrichmentFill(result)
-								const keptContacts = contactFill(result)
 								yield* Effect.annotateCurrentSpan({
 									'research.enrichment.filled_kept': keptFill.filled,
 									'research.enrichment.missing_kept': keptFill.missing.length,
-									'research.contacts.named_kept': keptContacts.named,
-									'research.contacts.titled_kept': keptContacts.titled,
 								})
 							}
+							// People, counted for whichever shape the run is. A search
+							// files them on each company rather than on the run, and
+							// reporting only the second shape left a search that named two
+							// hundred and one that named none reading exactly alike.
+							const keptContacts = contactFill(result)
+							yield* Effect.annotateCurrentSpan({
+								'research.contacts.named_kept': keptContacts.named,
+								'research.contacts.titled_kept': keptContacts.titled,
+							})
 							return {
 								findings: result as unknown,
 								entityFieldsDropped,

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -43,7 +43,10 @@ import {
 	validateFindingCitations,
 } from './citation-guard'
 import { ContactDiscovery } from './contact-discovery'
-import { bindContactsToEntity } from './contact-entity-guard'
+import {
+	bindContactsToEntity,
+	bindScanContactsToRows,
+} from './contact-entity-guard'
 import {
 	ContactsRescueSchema,
 	contactsRescuePrompt,
@@ -1299,7 +1302,7 @@ export const buildResearchSystemPrompt = (args: {
 		'For a citation to a page you scraped, set source_id to the exact URL you scraped with scrape_page. Never invent an identifier — a made-up source is dropped.',
 		`Name the people who run the company — each with the exact title they are given — and treat that as part of the job, not an extra. They are listed on a team, leadership, management or "equipo" page, almost never on the homepage, so open one when the site has it. ${
 			isDiscoveryScan(args.schemaName)
-				? 'When reading the pages turns up nobody with a title, the tools that would buy you names are not yours to call on a list of companies: add a `pending_paid_actions` entry naming discover_contacts and the company, and a person decides whether to spend it.'
+				? "Put each one in that company's own `contacts`, with the page you read them on — a list of companies is worth far more with somebody to ask for on each. When reading the pages turns up nobody, the tools that would buy you names are not yours to call on a list of companies: add a `pending_paid_actions` entry naming discover_contacts and the company, and a person decides whether to spend it."
 				: 'When reading the pages turns up nobody with a title, discover_contacts is the tool that finds them.'
 		}`,
 		'A search result quotes only the one sentence of a page that matched your query. When a page looks like it holds more than that sentence, open it with scrape_page rather than settling for the snippet.',
@@ -3863,10 +3866,15 @@ export class ResearchService extends Context.Service<ResearchService>()(
 											// Passes every person through when there are no keys: with
 											// nothing to hold a quote against, one naming another
 											// company cannot be told from one naming this company.
-											const check = bindContactsToEntity(
-												findings,
-												entityTargets,
-											)
+											// Two shapes, two checks. A run about one company holds its
+											// people against that company; a search returning many holds
+											// each row's people against that row.
+											const check = isDiscoveryScan(schemaName)
+												? bindScanContactsToRows(
+														findings,
+														discoveryResultField(schemaName),
+													)
+												: bindContactsToEntity(findings, entityTargets)
 											if (check.dropped > 0) {
 												yield* Effect.logWarning(
 													'research.contacts.wrong_entity',

--- a/packages/research/src/application/research-service.ts
+++ b/packages/research/src/application/research-service.ts
@@ -197,6 +197,7 @@ import { computeRunQuality, type PlaceStanding } from './research-quality'
 import { type RunWords, runWordsOf } from './run-words'
 import { guardScalarFields } from './scalar-field-guard'
 import { guardScanEvidence } from './scan-evidence-guard'
+import { teamPagesForRows } from './scan-team-pages'
 import {
 	type FreeformSchema,
 	isSchemaName,
@@ -6449,12 +6450,43 @@ export class ResearchService extends Context.Service<ResearchService>()(
 							),
 						)
 
-						// Grounded and fully fetched — nothing left to close.
-						if (unbought.length === 0 && citedWaiting.length === 0) break
+						// One page per company that came back with nobody, chosen from
+						// links the run genuinely saw. A run about a single company has
+						// swept its own site for these all along; a search never could,
+						// because that sweep hangs off the one company the run is about.
+						// Bought after the cited pages and before the searches, out of
+						// the same purse — a round with nothing left simply buys none.
+						const teamPages = teamPagesForRows({
+							findings,
+							listField: discoveryResultField(schemaName),
+							addresses: [...gatheredAddresses],
+							alreadyTried: url => {
+								const hash = urlHashForScrape(url)
+								return openedHashes.has(hash) || citedAttempted.has(hash)
+							},
+							max: Math.floor(
+								(spendable - citedToFetch.length * SCRAPE_COST_CENTS) /
+									SCRAPE_COST_CENTS,
+							),
+						})
+						// Grounded and fully fetched — nothing left to close. A page that
+						// would name a company's people counts as something left: a list
+						// whose rows are otherwise complete is exactly the one that would
+						// otherwise stop here with nobody to ask for on any of them.
+						if (
+							unbought.length === 0 &&
+							citedWaiting.length === 0 &&
+							teamPages.length === 0
+						)
+							break
 						// Something left to buy and nothing to buy it with. Said out loud:
 						// a run stopped for want of money leaves the same silence as one
 						// that closed every gap, and only the first is worth acting on.
-						if (perFieldTargets.length === 0 && citedToFetch.length === 0) {
+						if (
+							perFieldTargets.length === 0 &&
+							citedToFetch.length === 0 &&
+							teamPages.length === 0
+						) {
 							yield* Effect.logInfo('research.gap_rounds.stopped').pipe(
 								Effect.annotateLogs({
 									event: 'research.gap_rounds.stopped',
@@ -6558,6 +6590,61 @@ export class ResearchService extends Context.Service<ResearchService>()(
 														event: 'research.gap_rounds.cited_scrape_skipped',
 														research_id: researchId,
 														url: citedUrl,
+														cause: Cause.pretty(cause),
+													}),
+												),
+									),
+								),
+							{ concurrency: GAP_ROUND_CONCURRENCY },
+						)
+						yield* Effect.forEach(
+							teamPages,
+							target =>
+								Effect.gen(function* () {
+									citedAttempted.add(urlHashForScrape(target.url))
+									if (isUnsupportedScrapeUrl(target.url)) return
+									const page = yield* gapScrape.scrape({
+										url: target.url,
+										formats: ['markdown'],
+									})
+									gapSpentCents += SCRAPE_COST_CENTS
+									if (
+										page.markdown === undefined ||
+										page.markdown.trim().length === 0
+									)
+										return
+									gatheredAddresses.add(page.url)
+									for (const linked of linkedAddresses(page.markdown)) {
+										gatheredAddresses.add(linked)
+									}
+									const pageHash = urlHashForScrape(page.url)
+									roundHashes.push(pageHash)
+									scrapeCorpus.push({
+										urlHash: pageHash,
+										text: page.markdown,
+										host: domainHost(page.resolvedUrl ?? page.url),
+										kind: 'page',
+									})
+									yield* Effect.logInfo('research.gap_rounds.team_page').pipe(
+										Effect.annotateLogs({
+											event: 'research.gap_rounds.team_page',
+											research_id: researchId,
+											round: gapRound,
+											company: target.name,
+											url: target.url,
+										}),
+									)
+								}).pipe(
+									Effect.catchCause(cause =>
+										Cause.hasInterruptsOnly(cause)
+											? Effect.failCause(cause)
+											: Effect.logInfo(
+													'research.gap_rounds.team_page_skipped',
+												).pipe(
+													Effect.annotateLogs({
+														event: 'research.gap_rounds.team_page_skipped',
+														research_id: researchId,
+														url: target.url,
 														cause: Cause.pretty(cause),
 													}),
 												),

--- a/packages/research/src/application/scan-contacts-egein.test.ts
+++ b/packages/research/src/application/scan-contacts-egein.test.ts
@@ -1,0 +1,153 @@
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { bindScanContactsToRows } from './contact-entity-guard'
+import { buildExtractionPrompt } from './research-service'
+import { ProspectScanV1Schema } from './schemas/prospect-scan-v1'
+
+/**
+ * The run that found EGEIN fetched its team page and returned nobody.
+ *
+ * `egein.com/ca/equip` is in that run's stored sources, and it names 42 people
+ * with their titles. The row had no field for them and the extraction step was
+ * never asked, so all 42 were dropped. These hold every part of that path open
+ * except the model's own compliance, which needs a live extract call.
+ */
+
+// Read off the page as the run stored it, names and titles verbatim.
+const EGEIN_PEOPLE = [
+	{ name: 'David Garrido', role: 'CEO - Enginyer Industrial' },
+	{
+		name: 'Mariona Garrido',
+		role: 'CFO - Direcció Financera i Recursos Humans',
+	},
+	{ name: 'Rafel Alum', role: 'Enginyer industrial - BIM Manager' },
+	{ name: 'Jesús Muñoz', role: 'Controller Financer' },
+	{ name: 'Alexis Aguilar', role: "Cap d'obres - Arquitecte" },
+]
+
+const egeinRow = (contacts: ReadonlyArray<unknown>) => ({
+	name: "Enginyeria I Gestió D'Espais Industrials SL",
+	website: {
+		value: 'https://egein.com',
+		source_id: 'https://egein.com/ca',
+		confidence: 0.9,
+	},
+	why_relevant: 'Engineering and turnkey construction of industrial buildings.',
+	citations: [
+		{
+			quote: 'EGEIN',
+			source_id: 'https://egein.com/ca/equip',
+			confidence: 100,
+		},
+	],
+	contacts,
+})
+
+const withCitations = (people: ReadonlyArray<{ name: string; role: string }>) =>
+	people.map(p => ({
+		...p,
+		citations: [
+			{
+				quote: p.role,
+				source_id: 'https://egein.com/ca/equip',
+				confidence: 90,
+			},
+		],
+	}))
+
+describe('what a company search does with a team page it fetched', () => {
+	describe('when the run is a search for companies', () => {
+		it('should ask the extraction step for each company own people', () => {
+			// GIVEN the prompt the extraction step is actually given for a search
+			const prompt = buildExtractionPrompt({
+				query: "Empreses d'enginyeria industrial a Girona",
+				citationInstruction: '',
+				evidenceBlock: '',
+				subjects: [],
+				discoveryScan: true,
+			})
+
+			// WHEN it is read — THEN it asks for people, and says they belong to the
+			// company they work for rather than to a list of their own. Without this
+			// the run fetched EGEIN's team page and reported nobody.
+			expect(prompt).toContain('`contacts`')
+			expect(prompt).toMatch(/leader or employee/i)
+			expect(prompt).toMatch(/under the company they work for/i)
+		})
+
+		it('should not ask a run about one company for the same thing', () => {
+			// GIVEN the prompt for a run whose whole job is a single company, which
+			// keeps its people in a list of its own
+			const prompt = buildExtractionPrompt({
+				query: 'EGEIN',
+				citationInstruction: '',
+				evidenceBlock: '',
+				subjects: [],
+				discoveryScan: false,
+			})
+
+			// WHEN read — THEN it gets the people ask it always had, unchanged
+			expect(prompt).toContain('Name EVERY person')
+		})
+	})
+
+	describe('when the answer carries the people that page named', () => {
+		it('should be a shape the schema accepts', () => {
+			// GIVEN an answer holding EGEIN with five of its named staff
+			const decoded = Schema.decodeUnknownSync(ProspectScanV1Schema)({
+				prospects: [egeinRow(withCitations(EGEIN_PEOPLE))],
+			})
+
+			// WHEN decoded — THEN every person survives with their title, so what the
+			// page said reaches the findings rather than being dropped at the door
+			const people = decoded.prospects[0]?.contacts ?? []
+			expect(people).toHaveLength(5)
+			expect(people.map(p => p.name)).toContain('Mariona Garrido')
+			expect(people.find(p => p.name === 'David Garrido')?.role).toBe(
+				'CEO - Enginyer Industrial',
+			)
+		})
+
+		it('should keep them on EGEIN rather than the company listed beside it', () => {
+			// GIVEN EGEIN's own staff on EGEIN's row, and a second company whose row
+			// carries somebody the evidence ties to EGEIN instead
+			const findings = {
+				prospects: [
+					egeinRow(withCitations(EGEIN_PEOPLE)),
+					{
+						name: 'Calderería Empordà SL',
+						citations: [],
+						contacts: [
+							{
+								name: 'David Garrido',
+								role: 'CEO',
+								citations: [
+									{
+										quote: 'David Garrido, CEO at Egein Group',
+										source_id: 'https://egein.com/ca/equip',
+										confidence: 90,
+									},
+								],
+							},
+						],
+					},
+				],
+			}
+
+			// WHEN each row's people are held against that row
+			const result = bindScanContactsToRows(findings, 'prospects')
+			const rows = (
+				result.findings as {
+					prospects: ReadonlyArray<{ contacts: ReadonlyArray<unknown> }>
+				}
+			).prospects
+
+			// THEN EGEIN keeps its own and the misfiled one goes, which is the
+			// mistake a page naming many firms makes easiest
+			expect(rows[0]?.contacts).toHaveLength(5)
+			expect(rows[1]?.contacts).toHaveLength(0)
+			expect(result.dropped).toBe(1)
+		})
+	})
+})

--- a/packages/research/src/application/scan-team-pages.test.ts
+++ b/packages/research/src/application/scan-team-pages.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest'
+
+import { teamPagesForRows } from './scan-team-pages'
+
+const never = () => false
+
+describe('teamPagesForRows', () => {
+	describe('when a company came back with no people and links a team page', () => {
+		it('should pick that page', () => {
+			// GIVEN a company the run found, whose own site links an "equip" page
+			const picked = teamPagesForRows({
+				findings: {
+					prospects: [
+						{
+							name: 'Egein',
+							website: { value: 'https://egein.com', source_id: 'x' },
+							contacts: [],
+						},
+					],
+				},
+				listField: 'prospects',
+				addresses: [
+					'https://egein.com/ca/serveis',
+					'https://egein.com/ca/equip',
+					'https://egein.com/ca/contacte',
+				],
+				alreadyTried: never,
+				max: 3,
+			})
+
+			// THEN the team page is chosen over the services and contact pages
+			expect(picked).toEqual([
+				{ name: 'Egein', url: 'https://egein.com/ca/equip' },
+			])
+		})
+	})
+
+	describe('when the company already named somebody', () => {
+		it('should pass it over', () => {
+			// GIVEN a row that already carries a person
+			const picked = teamPagesForRows({
+				findings: {
+					prospects: [
+						{
+							name: 'Egein',
+							website: { value: 'https://egein.com', source_id: 'x' },
+							contacts: [{ name: 'David Garrido' }],
+						},
+					],
+				},
+				listField: 'prospects',
+				addresses: ['https://egein.com/ca/equip'],
+				alreadyTried: never,
+				max: 3,
+			})
+
+			// THEN nothing is bought for it: the round's money goes to a company
+			// that came back with nobody
+			expect(picked).toEqual([])
+		})
+	})
+
+	describe('when the run never saw a link to the company own pages', () => {
+		it('should pass it over rather than guess a path', () => {
+			// GIVEN a company whose site the run only knows the address of
+			const picked = teamPagesForRows({
+				findings: {
+					prospects: [
+						{
+							name: 'Talleres Vidal SL',
+							website: { value: 'https://talleresvidal.es', source_id: 'x' },
+							contacts: [],
+						},
+					],
+				},
+				listField: 'prospects',
+				addresses: ['https://otro.es/equipo'],
+				alreadyTried: never,
+				max: 3,
+			})
+
+			// THEN nothing: a guessed path is a fetch into a 404
+			expect(picked).toEqual([])
+		})
+	})
+
+	describe('when a row gave no address at all', () => {
+		it('should pass it over', () => {
+			expect(
+				teamPagesForRows({
+					findings: { prospects: [{ name: 'Sense Web', contacts: [] }] },
+					listField: 'prospects',
+					addresses: ['https://egein.com/ca/equip'],
+					alreadyTried: never,
+					max: 3,
+				}),
+			).toEqual([])
+		})
+	})
+
+	describe('when the best page was already fetched', () => {
+		it('should take the next one rather than pay for it twice', () => {
+			// GIVEN the team page already read this run
+			const picked = teamPagesForRows({
+				findings: {
+					prospects: [
+						{
+							name: 'Egein',
+							website: { value: 'https://egein.com', source_id: 'x' },
+							contacts: [],
+						},
+					],
+				},
+				listField: 'prospects',
+				addresses: [
+					'https://egein.com/ca/equip',
+					'https://egein.com/ca/empresa',
+				],
+				alreadyTried: url => url === 'https://egein.com/ca/equip',
+				max: 3,
+			})
+
+			// THEN the about page stands in for it
+			expect(picked).toEqual([
+				{ name: 'Egein', url: 'https://egein.com/ca/empresa' },
+			])
+		})
+	})
+
+	describe('when more companies want a page than the round can afford', () => {
+		it('should stop at what it was given', () => {
+			// GIVEN three companies with nobody named and a budget for one
+			const picked = teamPagesForRows({
+				findings: {
+					prospects: [
+						{ name: 'A', website: 'https://a.es', contacts: [] },
+						{ name: 'B', website: 'https://b.es', contacts: [] },
+						{ name: 'C', website: 'https://c.es', contacts: [] },
+					],
+				},
+				listField: 'prospects',
+				addresses: [
+					'https://a.es/equip',
+					'https://b.es/equip',
+					'https://c.es/equip',
+				],
+				alreadyTried: never,
+				max: 1,
+			})
+
+			// THEN one, so a long list cannot spend the whole purse on people
+			expect(picked).toHaveLength(1)
+		})
+	})
+
+	describe('when the only page a company links is a contact form', () => {
+		it('should buy nothing, rather than pay to meet a switchboard', () => {
+			// GIVEN a company whose site links a contact page and nothing else
+			const picked = teamPagesForRows({
+				findings: {
+					prospects: [
+						{
+							name: 'ER Enginy',
+							website: { value: 'https://erenginy.com', source_id: 'x' },
+							contacts: [],
+						},
+					],
+				},
+				listField: 'prospects',
+				addresses: ['https://erenginy.com/en/contact/'],
+				alreadyTried: never,
+				max: 3,
+			})
+
+			// THEN nothing is fetched: this sweep is looking for the people, and a
+			// real search opened exactly this page and came back with nobody
+			expect(picked).toEqual([])
+		})
+	})
+
+	describe('when the run is not a search', () => {
+		it('should return nothing', () => {
+			expect(
+				teamPagesForRows({
+					findings: { contacts: [] },
+					listField: undefined,
+					addresses: ['https://egein.com/ca/equip'],
+					alreadyTried: never,
+					max: 3,
+				}),
+			).toEqual([])
+		})
+	})
+})

--- a/packages/research/src/application/scan-team-pages.test.ts
+++ b/packages/research/src/application/scan-team-pages.test.ts
@@ -178,6 +178,70 @@ describe('teamPagesForRows', () => {
 		})
 	})
 
+	describe('when a company named its about page after itself', () => {
+		it('should find it, where no list of words in any language could', () => {
+			// GIVEN the real ER Enginy site, whose about page is "/ca/er-enginy" —
+			// a shape a small firm uses often and no keyword list can catch
+			const picked = teamPagesForRows({
+				findings: {
+					prospects: [
+						{
+							name: 'ER Enginy',
+							website: { value: 'https://www.erenginy.com', source_id: 'x' },
+							contacts: [],
+						},
+					],
+				},
+				listField: 'prospects',
+				addresses: [
+					'https://www.erenginy.com/ca/serveis',
+					'https://www.erenginy.com/ca/er-enginy',
+					'https://www.erenginy.com/ca/contacte',
+				],
+				alreadyTried: never,
+				max: 3,
+			})
+
+			// THEN that page, not the contact form the run used to settle for
+			expect(picked).toEqual([
+				{ name: 'ER Enginy', url: 'https://www.erenginy.com/ca/er-enginy' },
+			])
+		})
+	})
+
+	describe('when a company simply has no page about itself', () => {
+		it('should buy nothing at all', () => {
+			// GIVEN the real Bellmas site: services, project references and news,
+			// and nothing that talks about the firm or names its staff
+			const picked = teamPagesForRows({
+				findings: {
+					prospects: [
+						{
+							name: 'Bellmas Enginyers Associats S.L.',
+							website: {
+								value: 'https://www.bellmasenginyers.cat',
+								source_id: 'x',
+							},
+							contacts: [],
+						},
+					],
+				},
+				listField: 'prospects',
+				addresses: [
+					'https://www.bellmasenginyers.cat/ca/actualitat-i-noticies/nota-aclaridora-sobre-l-aplicacio',
+					'https://www.bellmasenginyers.cat/es/referencias/edificios-de-viviendas/conjunto-residencial-56-viviendas-en-calonge',
+					'https://www.bellmasenginyers.cat/es/ingenieria-industrial-civil-servicios',
+				],
+				alreadyTried: never,
+				max: 3,
+			})
+
+			// THEN nothing: a project of the company's own sitting on the same site
+			// is not the company talking about itself
+			expect(picked).toEqual([])
+		})
+	})
+
 	describe('when the run is not a search', () => {
 		it('should return nothing', () => {
 			expect(

--- a/packages/research/src/application/scan-team-pages.ts
+++ b/packages/research/src/application/scan-team-pages.ts
@@ -1,0 +1,89 @@
+/**
+ * Picks the one page per company most likely to name its people, for a search
+ * that came back with companies but no names.
+ *
+ * A run about a single company already sweeps its own site for the team and about
+ * pages, deterministically, rather than hoping the model navigates there. A search
+ * never did: that sweep hangs off the one company the run is about, and a search
+ * is about none. So a scan's people came only from whatever pages the model
+ * happened to open — two "about" pages across nine companies, in the run this was
+ * written for — while the extraction step sitting behind them can read a full
+ * roster off a team page without trouble.
+ *
+ * Nothing is guessed. The candidates are links the run genuinely saw on pages it
+ * already fetched, so a company that never linked a team page is passed over
+ * rather than fetched into a 404. One page per company, and only companies that
+ * came back with nobody, so the cost is bounded by how badly the list is doing
+ * rather than by its length.
+ */
+
+import { aboutPageCandidates } from './about-pages'
+import { domainHost } from './entity-guard'
+import { isValueWrapper, unwrapValue } from './guard-shapes'
+
+export interface TeamPageTarget {
+	/** The company the page belongs to, for the log line. */
+	readonly name: string
+	readonly url: string
+}
+
+const rowWebsite = (row: Record<string, unknown>): string | undefined => {
+	const website = row['website']
+	const address = isValueWrapper(website) ? unwrapValue(website) : website
+	return typeof address === 'string' && address.trim() !== ''
+		? address
+		: undefined
+}
+
+const namesNobody = (row: Record<string, unknown>): boolean => {
+	const contacts = row['contacts']
+	return !Array.isArray(contacts) || contacts.length === 0
+}
+
+export const teamPagesForRows = (args: {
+	readonly findings: unknown
+	readonly listField: string | undefined
+	/** Every address the run has seen linked, from the pages it already read. */
+	readonly addresses: ReadonlyArray<string>
+	/** Whether a page has been fetched, or tried, already. */
+	readonly alreadyTried: (url: string) => boolean
+	readonly max: number
+}): ReadonlyArray<TeamPageTarget> => {
+	const { findings, listField } = args
+	if (
+		args.max <= 0 ||
+		listField === undefined ||
+		findings === null ||
+		typeof findings !== 'object' ||
+		Array.isArray(findings)
+	) {
+		return []
+	}
+	const rows = (findings as Record<string, unknown>)[listField]
+	if (!Array.isArray(rows)) return []
+
+	const picked: TeamPageTarget[] = []
+	for (const row of rows) {
+		if (picked.length >= args.max) break
+		if (row === null || typeof row !== 'object') continue
+		const record = row as Record<string, unknown>
+		// A company that already named somebody has had its answer; the round's
+		// money is better spent on one that has not.
+		if (!namesNobody(record)) continue
+		const website = rowWebsite(record)
+		const host = website === undefined ? undefined : domainHost(website)
+		if (host === undefined) continue
+		// Team and about pages only. This sweep exists to find the people, and a
+		// contact page names a switchboard — buying one to look for staff spends
+		// the fetch and comes back with nobody.
+		const candidate = aboutPageCandidates(args.addresses, host, 4, 1).find(
+			url => !args.alreadyTried(url),
+		)
+		if (candidate === undefined) continue
+		picked.push({
+			name: typeof record['name'] === 'string' ? record['name'] : host,
+			url: candidate,
+		})
+	}
+	return picked
+}

--- a/packages/research/src/application/scan-team-pages.ts
+++ b/packages/research/src/application/scan-team-pages.ts
@@ -18,7 +18,7 @@
  */
 
 import { aboutPageCandidates } from './about-pages'
-import { domainHost } from './entity-guard'
+import { distinctiveWords, domainHost } from './entity-guard'
 import { isValueWrapper, unwrapValue } from './guard-shapes'
 
 export interface TeamPageTarget {
@@ -76,14 +76,13 @@ export const teamPagesForRows = (args: {
 		// Team and about pages only. This sweep exists to find the people, and a
 		// contact page names a switchboard — buying one to look for staff spends
 		// the fetch and comes back with nobody.
-		const candidate = aboutPageCandidates(args.addresses, host, 4, 1).find(
-			url => !args.alreadyTried(url),
-		)
+		const name = typeof record['name'] === 'string' ? record['name'] : ''
+		const candidate = aboutPageCandidates(args.addresses, host, 4, {
+			weakestBand: 1,
+			ownWords: distinctiveWords(name),
+		}).find(url => !args.alreadyTried(url))
 		if (candidate === undefined) continue
-		picked.push({
-			name: typeof record['name'] === 'string' ? record['name'] : host,
-			url: candidate,
-		})
+		picked.push({ name: name === '' ? host : name, url: candidate })
 	}
 	return picked
 }

--- a/packages/research/src/application/schemas/prospect-scan-v1.ts
+++ b/packages/research/src/application/schemas/prospect-scan-v1.ts
@@ -104,6 +104,36 @@ export const ProspectScanV1Schema = Schema.Struct({
 						'Only about whether this is a real, trading company: fill it when the evidence names the company but does not establish that it exists and trades, saying in a few words what is missing. Never drop a company for want of that — list it with this instead. A field you could not confirm is not a reason to fill this: leave that field out and this one too.',
 				}),
 			),
+			// The people a search could name from pages it already read, so a list of
+			// companies arrives with somebody to ask for rather than a name and a
+			// phone number nobody answers.
+			//
+			// Deliberately thinner than the shape a contact-discovery run fills. It
+			// holds what a page states — who they are and what they are called — and
+			// no way of reaching them: an address is either published, in which case
+			// the company's own email already carries it, or it is guessed and
+			// checked, which costs money per person and is work a person approves for
+			// one company rather than a search doing it for fifty.
+			contacts: Schema.optionalKey(
+				Schema.Array(
+					Schema.Struct({
+						name: Schema.String.annotate({
+							description:
+								'The person as the page names them, in full. Not a job title on its own, and not a department.',
+						}),
+						role: Schema.optionalKey(
+							Schema.String.annotate({
+								description:
+									'Their title exactly as the page gives it, in its own language — "Gerent", "Responsable de producció". Leave it out rather than translating or inventing one.',
+							}),
+						),
+						citations: Schema.Array(Citation),
+					}),
+				).annotate({
+					description:
+						'Only people this company\'s own pages name — a team, leadership, management or "equipo" page. Never a person read off a directory listing about the company, and never somebody carried over from another company on the list.',
+				}),
+			),
 			citations: Schema.Array(Citation),
 		}),
 	),


### PR DESCRIPTION
## What

When you ask Batuda to find companies, it now brings back the people those companies name on their own pages — so a list of fifty firms arrives with somebody to ask for, instead of a company name and a switchboard number.

It was already reading those pages and throwing the names away. One stored run had fetched `egein.com/ca/equip`, a page naming **42 people with their job titles**, and returned zero contacts: the shape a company search answers in (the `prospect_scan_v1` schema) had nowhere to put them, and the step that reads the evidence was never asked for people.

This sits in Research, across two surfaces: the research engine (`packages/research`, running in `server`) and the findings screen in the internal app.

## Changes

**Touches:** the shape a company search answers in, the instructions the reading step is given, the checks that decide whether a named person really belongs to the company beside them, the page-fetching that happens after the first pass, how spend is recorded when a supplier refuses a call, and the screen that shows the result.

- A company search carries the people each company's own pages name — who they are and what they are called, and nothing about how to reach them. An address is either published, in which case the company's own email already carries it, or it is guessed and checked, which costs money per person and is a decision a person makes for one company rather than a search making it for fifty.
- **Each company on the list is now checked the way a run about a single company is**, built from its own name and the address it gave. The checks in this codebase were all written for a run with one subject and quietly do nothing when there isn't one, so every protection a search needed was being written a second time. This is the change the rest lean on.
- A person only a directory names is refused — those rosters are scraped, years old, and list people who left. A job title that appears on no page the run actually read is removed and the person kept, because a model handed somebody with no stated title writes one and says so in the same breath (`Director/a (the page does not give the exact title)` reached a real row), and an invented title is what somebody opens a call with.
- After the first pass, **one page per company that came back with nobody** is fetched, chosen only from links the run genuinely saw, out of the same purse as the other gap-closing — so a round with nothing left buys none.
- Two page-picking bugs fixed along the way, both of which also affected a run about a single company: the picker knew `equipo` and `equipe` but not the Catalan **`equip`**, so a 42-person roster lost to a contact form; and it compared a site's sections whole, so a Catalan news section written as `actualitat-i-noticies` let press releases through as pages that would name staff.
- A paid call the supplier **refused outright** no longer charges the run.

## Impact

- **Spend changes, downward.** A supplier that says it has no credit left never billed for the work, so the charge is now voided while the row stays (it still records that the call was attempted). Register lookups had run up **€3.19 this way since the register ran out of credit on 2026-08-30** — money that also ate the organisation's monthly allowance and read in the spend breakdown as lookups that happened. `get_research_spend` totals and the monthly cap both get lower and truer.
- **Fetching changes, slightly upward.** A search may fetch up to one extra page per company that named nobody. It comes out of the existing per-run allowance rather than a new one, so it cannot overspend — it competes with the other gap-closing work. Measured on a one-province search: 9 of 100 internal units spent before, 12–16 after. A whole-country pass already runs near its ceiling, so there it will take from the gap rounds instead.
- **The answer shape gained a field.** Each company in a `prospect_scan_v1` result can now carry `contacts`. This is additive — nothing was renamed or removed — and the findings are stored as JSON, so **there is no database migration and nothing to run before deploying**. Anything reading raw findings over MCP sees the new field.
- **Nothing touching which organisation can see what (row-level security)**, no new environment variables, no change to who can reach which route, and no coordinated deploy needed. Nothing at the service level changed, so the MCP and HTTP surfaces stay in step.

## Review guide

- **Start at `packages/research/src/application/contact-entity-guard.ts`** — the riskiest file, and where the per-company checking lives. The thing to disagree with is the rule that refuses a person whom only a directory names: it is the one place here that chooses to lose a real person rather than keep an unreliable one, justified because the schema already says directory listings are not allowed. It only fires when the company gave an address, since without one nothing separates its own pages from a page about it.
- `scan-team-pages.ts` is new and small — it only *chooses* pages; the fetching is in `research-service.ts` inside the gap round.
- `budget.ts` — the charge is still written before the supplier is called, because the cap check and the debit have to be one indivisible step or two paid calls at once can both clear the same ceiling. Only the amount is corrected afterwards, and only on an explicit refusal; a call that failed on the way home is left alone, since there the supplier may well have billed.
- **Skip-able:** the `.po` catalogue lines are generated by `i18n:extract`.
- **Not verified:** Snyk was not run (the tool is not available in this session). The `ORG_PHRASE` matcher that both contact checks depend on reaches only **261 of 999 real company names** in the production data — it is ASCII-only and needs a legal-form suffix — and I deliberately left it alone: widening it trades a gap that keeps people for one that drops them, which is the worse direction. Worth its own issue.

## Screenshots

A real search result on the local stack: the people now sit in the company's own field list, beside where it is and what it does, above the one-click **Add as lead**. The citations under them are the pages they were read on — here the company's own site and a directory, kept because the company's own page backs it.

**Desktop (1440×900)**

![pr-scan-people-desktop.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-641/pr-scan-people-desktop.webp)

**Mobile (iPhone 16 Pro)** — both captured because this screen is mobile-first and the field list is the part that reflows.

![pr-scan-people-mobile.webp](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-641/pr-scan-people-mobile.webp)

## Tests

2,495 unit tests (up from 2,479), including: the guards that hold a person to the right company, the merge that used to discard a newly named person and a newly learned title, the eval reader, the ledger void on refusal, and the page picker. The two real sites the page picker got wrong are held open as tests, as is one that genuinely has no page about itself — so the rule is not read as a promise that every company has one.

## Verification

- Gates run: `pnpm install`, `pnpm -w check-types`, `pnpm -w test`, `pnpm -w build` — all green. `apps/server` integration suite (912 tests) run separately, green; the plain `test` task excludes it.
- **Three live searches** against the local stack with every paid supplier switched off, so no person could be bought. The last returned 31 companies for 12¢ and named 7 people, 7 with titles — where the eval previously reported `n/a` for people on a search.
- **One direct check of the reading step** against the real EGEIN team page, three samples: 42 of 42 people returned each time, every title copied verbatim in Catalan, every citation the page actually fetched.
- Screenshots taken against the local stack showing a real search result.

## Deferred

- The one-click **Add as lead** does not yet create these people as contacts on the new company, and `tax_id` is dropped on the way. A second click still creates a duplicate company.
- Adding a contact by hand fails unless a buying role is picked — a separate, pre-existing bug queued on its own.
- The `ORG_PHRASE` coverage ceiling described above.

---

Stacked on `research/scan-spend-and-lead-country` (PR #635), which merges first. Continuous integration does not run on a stacked pull request, so checks will appear once this is retargeted to `main`.
