### PR TITLE
feat: bring a prospect's people across when it becomes a lead

### DIFF
--- a/.claude/skills/crm/SKILL.md
+++ b/.claude/skills/crm/SKILL.md
@@ -86,8 +86,16 @@ Every document is filed against a CRM record — `subject_table` (`companies`, `
 
 When researching a new company:
 
-1. `create_companies(...)` with known fields
+1. `create_companies(...)` with known fields, and `contacts: [{ name, role }]` for anybody the company names on its own pages — they become contacts on it in the same call, so there is no round trip per person
 2. `create_document({ subject_table: "companies", subject_id: <id>, type: "research", content: <scraped + structured markdown> })`
+
+A company already on file comes back under `skipped`, with the company itself
+beside the reason. Act on `company.id`: the slug in that entry is the one that was
+sent, and on a `tax_id` match it is not the address the company is filed under.
+People sent with a skipped company land on it where its registration number
+matched — `tax_id` or `tax_id_in_request`, the same firm written down twice. Where
+only the web address matched — `slug` or `slug_in_request` — nothing is written,
+since a slug is folded from the name and two unrelated firms can reduce to one.
 
 A company's standing summary is `companies.account_brief`, not a document.
 

--- a/.claude/skills/crm/references/documents.md
+++ b/.claude/skills/crm/references/documents.md
@@ -34,7 +34,7 @@ These six are the whole list — the tools reject anything else.
 
 When researching a new company with Firecrawl/Exa:
 
-1. `create_companies(...)` with known fields (name, slug, industry, country, etc.)
+1. `create_companies(...)` with known fields (name, slug, industry, country, etc.), plus `contacts: [{ name, role }]` for the people the company names on its own pages
 2. `create_document({ subject_table: "companies", subject_id: <id>, type: "research", content: <scraped + structured markdown> })`
 
 Structure research documents with clear sections: overview, products/services, team, location, online presence, opportunities.

--- a/apps/internal/src/components/contacts/contact-edit-dialog.tsx
+++ b/apps/internal/src/components/contacts/contact-edit-dialog.tsx
@@ -77,7 +77,7 @@ export function ContactEditDialog({
 							...(trimmedRole ? { role: trimmedRole } : {}),
 							buyingRole: buyingRole === '' ? null : buyingRole,
 						},
-					} as never)
+					})
 				: await updateContact({
 						params: { id: contact.id },
 						payload: {
@@ -85,7 +85,7 @@ export function ContactEditDialog({
 							role: trimmedRole,
 							buyingRole: buyingRole === '' ? null : buyingRole,
 						},
-					} as never)
+					})
 		setBusy(false)
 		if (exit._tag === 'Success') {
 			onSaved()

--- a/apps/internal/src/components/contacts/contact-edit-dialog.tsx
+++ b/apps/internal/src/components/contacts/contact-edit-dialog.tsx
@@ -74,7 +74,7 @@ export function ContactEditDialog({
 						payload: {
 							companyId,
 							name: trimmedName,
-							...(trimmedRole ? { role: trimmedRole } : {}),
+							role: trimmedRole === '' ? null : trimmedRole,
 							buyingRole: buyingRole === '' ? null : buyingRole,
 						},
 					})
@@ -82,7 +82,7 @@ export function ContactEditDialog({
 						params: { id: contact.id },
 						payload: {
 							name: trimmedName,
-							role: trimmedRole,
+							role: trimmedRole === '' ? null : trimmedRole,
 							buyingRole: buyingRole === '' ? null : buyingRole,
 						},
 					})

--- a/apps/internal/src/components/research/findings/prospect-lead-payload.test.ts
+++ b/apps/internal/src/components/research/findings/prospect-lead-payload.test.ts
@@ -155,3 +155,80 @@ describe('buildLeadPayload', () => {
 		})
 	})
 })
+
+describe("the people a search read off the company's own pages", () => {
+	describe('when the run named some', () => {
+		it('should carry them across with their job titles', () => {
+			// GIVEN a prospect whose own team page named two people
+			const { payload } = buildLeadPayload(
+				{
+					name: 'Egein',
+					contacts: [
+						{ name: 'David Garrido', role: 'CEO - Enginyer Industrial' },
+						{ name: 'Mariona Garrido' },
+					],
+				},
+				'egein',
+			)
+
+			// THEN both travel with the company, the untitled one without a title
+			// invented for her
+			expect(payload.contacts).toEqual([
+				{ name: 'David Garrido', role: 'CEO - Enginyer Industrial' },
+				{ name: 'Mariona Garrido' },
+			])
+		})
+	})
+
+	describe('when an entry has a title but nobody to hang it on', () => {
+		it('should leave it out', () => {
+			// GIVEN a blank name beside a real one
+			const { payload } = buildLeadPayload(
+				{
+					name: 'Egein',
+					contacts: [{ name: '  ', role: 'Gerent' }, { name: 'David Garrido' }],
+				},
+				'egein',
+			)
+
+			// THEN only the person who can be asked for is carried: a contact with
+			// no name is one nobody can be asked for
+			expect(payload.contacts).toEqual([{ name: 'David Garrido' }])
+		})
+	})
+
+	describe('when the run named nobody', () => {
+		it('should leave the field off entirely', () => {
+			// GIVEN a company with no people on its pages
+			const { payload } = buildLeadPayload({ name: 'Egein' }, 'egein')
+
+			// THEN nothing is sent rather than an empty list
+			expect(payload.contacts).toBeUndefined()
+		})
+	})
+})
+
+describe('the number a company is registered under', () => {
+	describe('when the run read one', () => {
+		it('should carry it, since it is what recognises the firm again', () => {
+			// GIVEN a prospect whose registration number the run found
+			const { payload } = buildLeadPayload(
+				{ name: 'Egein', tax_id: 'B17234567' },
+				'egein',
+			)
+
+			// THEN it travels: the name and the web address both change, the
+			// registration does not
+			expect(payload.taxId).toBe('B17234567')
+		})
+	})
+
+	describe('when the run read none', () => {
+		it('should leave it off', () => {
+			expect(
+				buildLeadPayload({ name: 'Egein', tax_id: '  ' }, 'egein').payload
+					.taxId,
+			).toBeUndefined()
+		})
+	})
+})

--- a/apps/internal/src/components/research/findings/prospect-lead-payload.test.ts
+++ b/apps/internal/src/components/research/findings/prospect-lead-payload.test.ts
@@ -180,6 +180,30 @@ describe("the people a search read off the company's own pages", () => {
 		})
 	})
 
+	describe('when a title is blank or only spaces', () => {
+		it('should leave the title off rather than carry a blank one', () => {
+			// GIVEN two people the run named, one with an empty title and one whose
+			// title is nothing but spacing
+			const { payload } = buildLeadPayload(
+				{
+					name: 'Egein',
+					contacts: [
+						{ name: 'David Garrido', role: '' },
+						{ name: 'Mariona Garrido', role: '   ' },
+					],
+				},
+				'egein',
+			)
+
+			// THEN both travel with no title at all. A blank title passes every
+			// check for having one, and would be read back as a finding
+			expect(payload.contacts).toEqual([
+				{ name: 'David Garrido' },
+				{ name: 'Mariona Garrido' },
+			])
+		})
+	})
+
 	describe('when an entry has a title but nobody to hang it on', () => {
 		it('should leave it out', () => {
 			// GIVEN a blank name beside a real one

--- a/apps/internal/src/components/research/findings/prospect-lead-payload.ts
+++ b/apps/internal/src/components/research/findings/prospect-lead-payload.ts
@@ -32,6 +32,10 @@ export interface ProspectLeadSource {
 	readonly social_profiles?:
 		| ReadonlyArray<{ readonly kind: string; readonly value: string }>
 		| undefined
+	readonly tax_id?: string | undefined
+	readonly contacts?:
+		| ReadonlyArray<{ readonly name: string; readonly role?: string }>
+		| undefined
 }
 
 export interface LeadPayload {
@@ -46,6 +50,11 @@ export interface LeadPayload {
 		readonly socialProfiles?: ReadonlyArray<{
 			readonly kind: string
 			readonly value: string
+		}>
+		readonly taxId?: string
+		readonly contacts?: ReadonlyArray<{
+			readonly name: string
+			readonly role?: string
 		}>
 	}
 	/** Empty when everything the run said could be carried across. */
@@ -76,9 +85,8 @@ const usableProfiles = (source: ProspectLeadSource) =>
 		.map(p => ({ kind: p.kind.trim(), value: p.value.trim() }))
 
 /**
- * The slug is passed in rather than built here because it carries a random
- * suffix, and a function that answers differently each time cannot be tested by
- * asking it twice.
+ * The web address is passed in rather than built here, so the caller decides
+ * what a company is filed under and this stays a plain reading of the row.
  */
 export const buildLeadPayload = (
 	source: ProspectLeadSource,
@@ -101,6 +109,15 @@ export const buildLeadPayload = (
 		dropped.push('website')
 
 	const profiles = usableProfiles(source)
+	const taxId = source.tax_id?.trim()
+	// Only people with a name to file them under. A row carrying a title and
+	// nobody to hang it on would become a contact nobody can be asked for.
+	const people = (source.contacts ?? []).flatMap(person => {
+		const name = person.name?.trim() ?? ''
+		if (name === '') return []
+		const role = person.role?.trim()
+		return [role ? { name, role } : { name }]
+	})
 
 	return {
 		payload: {
@@ -112,6 +129,8 @@ export const buildLeadPayload = (
 			...(source.location ? { location: source.location } : {}),
 			...(storableWebsite ? { website: storableWebsite } : {}),
 			...(profiles.length > 0 ? { socialProfiles: profiles } : {}),
+			...(taxId ? { taxId } : {}),
+			...(people.length > 0 ? { contacts: people } : {}),
 		},
 		dropped,
 	}

--- a/apps/internal/src/components/research/findings/prospect-scan-view.tsx
+++ b/apps/internal/src/components/research/findings/prospect-scan-view.tsx
@@ -372,13 +372,38 @@ function AddAsLeadButton({
 			toast.add({ title: t`Could not add as a lead`, type: 'error' })
 			return
 		}
-		const row = exit.value as Record<string, unknown>
-		const id = typeof row['id'] === 'string' ? row['id'] : null
-		const newSlug = typeof row['slug'] === 'string' ? row['slug'] : slug
+		const { company, created, contactsAdded: peopleAdded } = exit.value
+		const id = company.id
+		const alreadyOnFile = !created
+		// Said under the headline rather than folded into it: the headline is about
+		// the company, and a count of people crammed into every branch of it would
+		// have to agree with each one separately.
+		const peopleNote =
+			peopleAdded === 0
+				? {}
+				: {
+						description:
+							peopleAdded === 1
+								? t`1 person added`
+								: t`${peopleAdded} people added`,
+					}
+		// Already here, so nothing is vouched for and nothing is reported as
+		// dropped: this click wrote no fields, and naming what it did not carry
+		// would read as a loss that just happened.
+		if (alreadyOnFile) {
+			setBusy(false)
+			toast.add({
+				title: t`Already on file`,
+				type: 'success',
+				...peopleNote,
+			})
+			void navigate({ to: '/companies/$slug', params: { slug: company.slug } })
+			return
+		}
 		// What the company ended up as, not what this click meant it to be: the
 		// vouching step is a second call that can fail on its own, and a message
 		// read off the intent would say verified when it is not.
-		const vouchWanted = id !== null && !heldBack
+		const vouchWanted = !heldBack
 		const verified =
 			vouchWanted &&
 			(
@@ -405,6 +430,7 @@ function AddAsLeadButton({
 						? t`Added, but could not be marked verified`
 						: t`Added, but could not be marked verified, leaving out: ${left}`,
 				type: 'error',
+				...peopleNote,
 			})
 		} else if (left !== '') {
 			// Written as a list rather than "without its X", which reads as one
@@ -414,6 +440,7 @@ function AddAsLeadButton({
 					? t`Added as a verified lead, leaving out: ${left}`
 					: t`Added as an unverified lead, leaving out: ${left}`,
 				type: 'success',
+				...peopleNote,
 			})
 		} else {
 			toast.add({
@@ -421,9 +448,10 @@ function AddAsLeadButton({
 					? t`Added as a verified lead`
 					: t`Added as an unverified lead`,
 				type: 'success',
+				...peopleNote,
 			})
 		}
-		void navigate({ to: '/companies/$slug', params: { slug: newSlug } })
+		void navigate({ to: '/companies/$slug', params: { slug: company.slug } })
 	}
 
 	return (
@@ -461,13 +489,16 @@ function AddAsLeadButton({
 	)
 }
 
-// A web address for a prospect, with a short random suffix so two prospects of the
-// same name (or an existing company) don't collide.
+// A web address for a prospect, read off its name and nothing else.
+//
+// No random suffix, so the same prospect gives the same address every time.
+// Colliding with a company already on file is the point — it is how the same firm
+// is recognised — and the answer then says the company is already here and takes
+// the person to it.
 //
 // The name is read by the shared rule rather than here, because reading it here got
 // it wrong both ways: "Calderería Sentmenat" came out "caldereri-a-sentmenat", and
 // "北京科技有限公司" came out "lead-x7f2q" with the company's own name nowhere in it.
 function toSlug(name: string): string {
-	const suffix = Math.random().toString(36).slice(2, 7)
-	return `${companySlugFromName(name)}-${suffix}`
+	return companySlugFromName(name)
 }

--- a/apps/internal/src/locales/ca/messages.po
+++ b/apps/internal/src/locales/ca/messages.po
@@ -226,6 +226,10 @@ msgstr "Seccions de {groupLabel}"
 msgid "{name} is back"
 msgstr "{name} ha tornat"
 
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "{peopleAdded} people added"
+msgstr "S'hi han afegit {peopleAdded} persones"
+
 #: src/components/research/research-dialog.tsx
 msgid "{scoped} (default)"
 msgstr "{scoped} (per defecte)"
@@ -298,6 +302,10 @@ msgstr "1 missatge"
 #: src/routes/emails/index.tsx
 msgid "1 msg"
 msgstr "1 missatge"
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "1 person added"
+msgstr "S'hi ha afegit 1 persona"
 
 #: src/routes/companies/$slug.tsx
 msgid "1 person went with it"
@@ -618,6 +626,10 @@ msgstr "ja hi diu {0}"
 #: src/components/research/findings/shared.tsx
 msgid "Already in CRM"
 msgstr "Ja al CRM"
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Already on file"
+msgstr "Ja hi és"
 
 #: src/components/research/proposal-outcome.tsx
 msgid "Already resolved"

--- a/apps/internal/src/locales/en/messages.po
+++ b/apps/internal/src/locales/en/messages.po
@@ -226,6 +226,10 @@ msgstr "{groupLabel} sections"
 msgid "{name} is back"
 msgstr "{name} is back"
 
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "{peopleAdded} people added"
+msgstr "{peopleAdded} people added"
+
 #: src/components/research/research-dialog.tsx
 msgid "{scoped} (default)"
 msgstr "{scoped} (default)"
@@ -298,6 +302,10 @@ msgstr "1 message"
 #: src/routes/emails/index.tsx
 msgid "1 msg"
 msgstr "1 msg"
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "1 person added"
+msgstr "1 person added"
 
 #: src/routes/companies/$slug.tsx
 msgid "1 person went with it"
@@ -618,6 +626,10 @@ msgstr "already {0}"
 #: src/components/research/findings/shared.tsx
 msgid "Already in CRM"
 msgstr "Already in CRM"
+
+#: src/components/research/findings/prospect-scan-view.tsx
+msgid "Already on file"
+msgstr "Already on file"
 
 #: src/components/research/proposal-outcome.tsx
 msgid "Already resolved"

--- a/apps/server/src/handlers/companies.ts
+++ b/apps/server/src/handlers/companies.ts
@@ -39,24 +39,32 @@ export const CompaniesLive = HttpApiBuilder.group(
 						),
 					),
 				)
-				.handle('create', _ =>
-					svc.create(_.payload).pipe(
-						Effect.flatMap(r =>
-							r[0] === undefined
-								? Effect.die(new Error('company insert returned no row'))
-								: Effect.succeed(r[0]),
-						),
-						Effect.tap(c =>
-							Effect.logInfo('Company created').pipe(
-								Effect.annotateLogs({
-									event: 'company.created',
-									slug: c.slug,
-								}),
+				.handle('create', _ => {
+					const { contacts, ...company } = _.payload
+					return svc
+						.createWithContacts({
+							company,
+							contacts: contacts ?? [],
+						})
+						.pipe(
+							Effect.tap(result =>
+								Effect.logInfo(
+									result.created
+										? 'Company created'
+										: 'Company already on file',
+								).pipe(
+									Effect.annotateLogs({
+										event: result.created
+											? 'company.created'
+											: 'company.already_on_file',
+										slug: result.company.slug,
+										contacts_added: result.contactsAdded,
+									}),
+								),
 							),
-						),
-						Effect.orDie,
-					),
-				)
+							Effect.orDie,
+						)
+				})
 				.handle('update', _ =>
 					Effect.gen(function* () {
 						// Capture the stage before the write so a change can be recorded

--- a/apps/server/src/handlers/contacts.ts
+++ b/apps/server/src/handlers/contacts.ts
@@ -4,7 +4,7 @@ import type { Statement } from 'effect/unstable/sql'
 import { SqlClient } from 'effect/unstable/sql'
 
 import { BatudaApi, CurrentOrg, NotFound } from '@batuda/controllers'
-import { Contact, ContactChannel } from '@batuda/domain'
+import { Contact, ContactChannel, jobTitleOrNothing } from '@batuda/domain'
 
 import {
 	pageOf,
@@ -118,6 +118,7 @@ export const ContactsLive = HttpApiBuilder.group(
 						)
 						const rows = yield* sql`INSERT INTO contacts ${sql.insert({
 							...fields,
+							role: jobTitleOrNothing(fields.role),
 							siteId: ownedSite ?? null,
 							organizationId: currentOrg.id,
 						})} RETURNING *`
@@ -167,8 +168,14 @@ export const ContactsLive = HttpApiBuilder.group(
 						// phone number does not wipe where that person works.
 						const siteChange =
 							ownedSite === undefined ? {} : { siteId: ownedSite }
+						// A blank box is a caller taking the title off; no field at all is a
+						// caller not mentioning it.
+						const roleChange =
+							fields.role === undefined
+								? {}
+								: { role: jobTitleOrNothing(fields.role) }
 						const rows = yield* sql`
-							UPDATE contacts SET ${sql.update({ ...fields, ...siteChange, updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) })}
+							UPDATE contacts SET ${sql.update({ ...fields, ...roleChange, ...siteChange, updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()) })}
 							WHERE id = ${_.params.id} RETURNING *
 						`
 						if (channels && channels.length > 0)

--- a/apps/server/src/mcp/tools/companies.ts
+++ b/apps/server/src/mcp/tools/companies.ts
@@ -236,14 +236,36 @@ const companyInputFields = {
 		description:
 			'Anything else worth keeping on this company, as a JSON object of your own shape. Searchable later through search_companies with metadata_key + metadata_value. Your own view of whether a company is worth selling to belongs here, by convention as `fitVerdict`: the separate fit_verdict field is what a research run concluded and nothing but a run writes it, so a judgement of your own has nowhere else to live.',
 	}),
+	contacts: Schema.optionalKey(
+		Schema.Array(
+			Schema.Struct({
+				name: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
+				role: Schema.optionalKey(Schema.NullOr(Schema.String)),
+			}),
+		),
+	).annotate({
+		description:
+			'The people this company names on its own pages, each as { name, role } — role being the job title as the page gives it, kept word for word, though a blank one is stored as no title at all. Use it for the people a discovery scan read off a company\'s site: they become contacts on the company in the same call, so a shortlist arrives with somebody to ask for instead of a switchboard number — except where the company is skipped on its web address alone, when they are dropped and the tool description says why. There is deliberately no field here for the part somebody plays in a purchase: a page gives a job title and nothing about who holds the budget, so that is for a person to add later with update_contact. Offer the same person twice, or somebody the company already has, and they are written once — accents are folded, so "Mercè Solà" and "Merce Sola" are one person.',
+	}),
 }
 const CompanyInput = Schema.Struct(companyInputFields)
 
 // Written from the vocabularies rather than typed out beside them. The typed-out
 // version drifted: it offered three statuses the app has never had and a priority
 // range twice the real one, and assistants followed it into rows that show up in
-// no board column. Now the sentence cannot say anything the schema would refuse.
-export const CREATE_COMPANIES_DESCRIPTION = `Create one or more companies in a single call — pass \`companies\` as an array (a single element to create just one, the whole shortlist to load a batch). Slug: leave it out and it is worked out from the name — supply one only to choose a particular web address. It must be plain lowercase a-z, digits and single hyphens, so an accented or non-Latin name cannot be written into one directly. Status: ${COMPANY_STATUSES.join('|')} (default: prospect). ownerId assigns the colleague who will work the company — pass a user id from list_members, or leave it out to create it unowned. It only lands on companies actually created: a skipped duplicate keeps the owner it already had, so re-sending a list is never a way to hand companies over. Use update_company for that. Priority: ${COMPANY_PRIORITIES[0]} (highest) to ${COMPANY_PRIORITIES[COMPANY_PRIORITIES.length - 1]} (lowest, default: 2). Pass taxId whenever you know it: a company is skipped if its slug already exists OR its registration number already does, so the number catches the same firm arriving under a different trading name. Runs in one transaction; a skip is not an error, so re-running an overlapping list is safe. Returns { created, skipped, created_needs_review }. Read the split this way: created and created_needs_review were both WRITTEN; only skipped was not. \`skipped\` gives each left-out slug plus matched_on — "slug" or "tax_id" when that identity was already on file before this call, "slug_in_request" or "tax_id_in_request" when the same company appeared twice in the list you just sent (a mistake in the list, not a company already in the CRM). \`created_needs_review\` gives companies that DID land but resemble another one: matches_slug and matches_name name the lookalike, matches says whether it is "on_file" (already in the CRM) or "in_request" (another entry in this same call), and matched_on says whether they share a web address or just a similar name — a website match reports confidence 100, which only means the host was identical, never that the row was rejected. Check those before treating them as separate companies. A company taken from a discovery scan's prospect list is a candidate, not a fact. Four things on that row say the run held it back, and they are separate: \`unconfirmed_reason\` is the run's own words on why it could not establish the company is real, \`${NAME_ONLY_EVIDENCE_FIELD}\` of "${NAME_ONLY_EVIDENCE}" means every page citing it was a list of many companies and it has neither a site nor a place of its own, \`${MARKS_FIELD}\` containing "${EXISTENCE_UNCONFIRMED}" means the run could not establish the company is real and trading, with what was missing in \`${EXISTENCE_REASON_FIELD}\`, and \`${MARKS_FIELD}\` containing "${OUTSIDE_REQUESTED_PLACE}" means the evidence puts it somewhere other than the area that was asked about. Any of the four: say so to the person before creating it, and never record it as verified on this run's word alone.`
+// no board column. The sentence cannot say anything the schema would refuse.
+export const CREATE_COMPANIES_DESCRIPTION = `Create one or more companies in a single call — pass \`companies\` as an array (a single element to create just one, the whole shortlist to load a batch). Slug: leave it out and it is worked out from the name — supply one only to choose a particular web address. It must be plain lowercase a-z, digits and single hyphens, so an accented or non-Latin name cannot be written into one directly. Status: ${COMPANY_STATUSES.join('|')} (default: prospect). ownerId assigns the colleague who will work the company — pass a user id from list_members, or leave it out to create it unowned. It only lands on companies actually created: a skipped duplicate keeps the owner it already had, so re-sending a list is never a way to hand companies over. Use update_company for that. Priority: ${COMPANY_PRIORITIES[0]} (highest) to ${COMPANY_PRIORITIES[COMPANY_PRIORITIES.length - 1]} (lowest, default: 2). Pass taxId whenever you know it: a company is skipped if its slug already exists OR its registration number already does, so the number catches the same firm arriving under a different trading name. Pass \`contacts\` inside a company's own object, not beside the list, to take its people on in the same call. Runs in one transaction; a skip is not an error, so re-running an overlapping list is safe. Returns { created, contacts_added, skipped, created_needs_review }. Read the split this way: created and created_needs_review were both WRITTEN; only skipped was not — though a skipped company's people may still have landed on it. contacts_added counts the people written across the whole call. \`skipped\` gives each left-out slug plus matched_on — "slug" or "tax_id" when that identity was already on file before this call, "slug_in_request" or "tax_id_in_request" when the same company appeared twice in the list you just sent (a mistake in the list, not a company already in the CRM) — and \`company\`, the one it matched: its id, web address, name, place and registration number. Act on it through company.id, never through the slug beside it, because that slug is the one YOU sent and on a tax_id match it may not be the web address the company is filed under. People offered with a skipped company land on it where its registration number matched — tax_id or tax_id_in_request, one firm written down twice, so they are its people. Where only the web address matched — slug or slug_in_request — nothing is written, those people included: a web address is folded from the name, so two unrelated firms reduce to one often enough that adding people there would file them under somebody else and report it as done. Read the company it matched: if it is the same firm, use create_contact for the people; if it is not, this company was never created, so send it again under a web address of its own. \`created_needs_review\` gives companies that DID land but resemble another one: matches_slug and matches_name name the lookalike, matches says whether it is "on_file" (already in the CRM) or "in_request" (another entry in this same call), and matched_on says whether they share a web address or just a similar name — a website match reports confidence 100, which only means the host was identical, never that the row was rejected. Check those before treating them as separate companies. A company taken from a discovery scan's prospect list is a candidate, not a fact. Four things on that row say the run held it back, and they are separate: \`unconfirmed_reason\` is the run's own words on why it could not establish the company is real, \`${NAME_ONLY_EVIDENCE_FIELD}\` of "${NAME_ONLY_EVIDENCE}" means every page citing it was a list of many companies and it has neither a site nor a place of its own, \`${MARKS_FIELD}\` containing "${EXISTENCE_UNCONFIRMED}" means the run could not establish the company is real and trading, with what was missing in \`${EXISTENCE_REASON_FIELD}\`, and \`${MARKS_FIELD}\` containing "${OUTSIDE_REQUESTED_PLACE}" means the evidence puts it somewhere other than the area that was asked about. Any of the four: say so to the person before creating it, and never record it as verified on this run's word alone.`
+
+// Enough of the company that matched to act on it and to judge whether it is the
+// same firm. Not the whole record: a re-sent list of fifty would come back as
+// fifty full account briefs.
+const CompanyMatched = Schema.Struct({
+	id: Schema.String,
+	slug: Schema.String,
+	name: Schema.String,
+	location: Schema.NullOr(Schema.String),
+	taxId: Schema.NullOr(Schema.String),
+})
 
 // What the service calls a skip, in the words the tool answers with.
 const SKIPPED_BECAUSE = {
@@ -260,8 +282,14 @@ const CreateCompanies = Tool.make('create_companies', {
 	}),
 	success: Schema.Struct({
 		created: Schema.Array(Company.json),
+		// People written, across the whole call. Anyone a company already had is
+		// not counted again.
+		contacts_added: Schema.Number,
 		// Not written, because something with this identity was there already —
-		// either on file before this call, or earlier in this same request.
+		// either on file before this call, or earlier in this same request. The
+		// company that matched comes back with it, because the slug beside it is the
+		// one the caller sent: on a number match that is not the address the company
+		// is filed under, so it is no use for going to look.
 		skipped: Schema.Array(
 			Schema.Struct({
 				slug: Schema.String,
@@ -271,6 +299,7 @@ const CreateCompanies = Tool.make('create_companies', {
 					'slug_in_request',
 					'tax_id_in_request',
 				]),
+				company: CompanyMatched,
 			}),
 		),
 		// Written, and worth a second look: every company named here landed, and
@@ -640,12 +669,28 @@ export const CompanyHandlersLive = CompanyTools.toLayer(
 							website: c.website,
 						})),
 					)
-					const batch = yield* service.createMany(companies)
+					// The people are held beside the company, not among its fields: the
+					// write builds its column list from the keys it is handed, so a
+					// `contacts` left in there becomes a column the table does not have.
+					const batch = yield* service.createMany(
+						companies.map(({ contacts, ...company }) => ({
+							company,
+							contacts: contacts ?? [],
+						})),
+					)
 					return {
 						created: batch.created,
+						contacts_added: batch.contactsAdded,
 						skipped: batch.skipped.map(skip => ({
 							slug: skip.slug,
 							matched_on: SKIPPED_BECAUSE[skip.matchedOn],
+							company: {
+								id: skip.company.id,
+								slug: skip.company.slug,
+								name: skip.company.name,
+								location: skip.company.location,
+								taxId: skip.company.taxId,
+							},
 						})),
 						created_needs_review: needsReview,
 					}

--- a/apps/server/src/mcp/tools/company-create-contacts.integration.test.ts
+++ b/apps/server/src/mcp/tools/company-create-contacts.integration.test.ts
@@ -1,0 +1,438 @@
+// Live-DB integration test for the people a company brings with it when an
+// assistant creates it. Driven through the real toolkit handlers the way a
+// `tools/call` would, inside the same org RLS scope (`enterOrgScope`) the /mcp
+// middleware applies.
+//
+// One call writes the company and the people its pages name, and a company
+// already on file comes back with the answer — so neither needs a lookup of its
+// own.
+//
+// Prereq: `pnpm cli services up` — the integration runner's globalSetup builds,
+// migrates and seeds the disposable database this suite runs against.
+
+import { randomUUID } from 'node:crypto'
+
+import { Cause, Effect, Layer, ManagedRuntime, Stream } from 'effect'
+import { FetchHttpClient } from 'effect/unstable/http'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import type { CurrentOrg } from '@batuda/controllers'
+import { TimelineActivityService } from '@batuda/timeline'
+
+import { PgLive } from '../../db/client'
+import { EnvVars } from '../../lib/env'
+import { enterOrgScope } from '../../middleware/org'
+import { CompanyService } from '../../services/companies'
+import { Geocoder } from '../../services/geocoder'
+import { applyTestEnv } from '../../test-env'
+import { CurrentUser } from '../current-user'
+import { isToolMessage } from '../tool-message'
+import { CompanyHandlersLive, CompanyTools } from './companies'
+
+applyTestEnv()
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+
+// Every name this suite creates carries the marker, so teardown can find its rows
+// whatever web address they ended up under.
+const MARKER = `lead-people-${randomUUID()}`
+
+type Org = { id: string; name: string; slug: string }
+
+const Handlers = CompanyHandlersLive.pipe(
+	Layer.provide(CompanyService.layer),
+	Layer.provide(TimelineActivityService.layer),
+	Layer.provide(Geocoder.layer),
+	Layer.provide(FetchHttpClient.layer),
+)
+const makeRuntime = () =>
+	ManagedRuntime.make(PgLive.pipe(Layer.provide(EnvVars.layer)))
+
+let pool: pg.Pool
+let runtime: ReturnType<typeof makeRuntime>
+let org: Org
+let actorId: string
+
+type Outcome =
+	| { ok: true; result: Record<string, unknown> | null }
+	| { ok: false; message: string }
+
+// What the tool actually said. A stringified cause carries stack frames and SQL,
+// so a check against that passes on almost any error.
+const toolMessageOf = (cause: Cause.Cause<unknown>): string => {
+	const spoken = Cause.squash(cause)
+	return isToolMessage(spoken)
+		? spoken.message
+		: `not a message written for the caller: ${String(spoken)}`
+}
+
+const runInOrg = <A, E>(
+	body: Effect.Effect<A, E, CurrentOrg | SqlClient.SqlClient>,
+): Promise<A> =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* enterOrgScope(sql, { org, userId: actorId })(body)
+		}),
+	)
+
+const actor = () => ({
+	userId: actorId,
+	email: `${actorId}@verify.local`,
+	name: 'Verifier',
+	isAgent: true,
+})
+
+const collect = <E, R>(
+	stream: Stream.Stream<{ readonly result: unknown }, E, R>,
+): Effect.Effect<Outcome, never, R> =>
+	Stream.runCollect(stream).pipe(
+		Effect.map(([first]) => ({
+			ok: true as const,
+			result: (first?.result ?? null) as Record<string, unknown> | null,
+		})),
+		Effect.catchCause(cause =>
+			Effect.succeed({ ok: false as const, message: toolMessageOf(cause) }),
+		),
+	)
+
+type Offered = {
+	readonly name: string
+	readonly taxId?: string
+	readonly location?: string
+	readonly contacts?: ReadonlyArray<{
+		readonly name: string
+		readonly role?: string
+	}>
+}
+
+const createCompanies = (companies: ReadonlyArray<Offered>): Promise<Outcome> =>
+	runInOrg(
+		Effect.gen(function* () {
+			const toolkit = yield* CompanyTools
+			return yield* collect(
+				yield* toolkit.handle('create_companies', { companies }),
+			)
+		}).pipe(
+			Effect.provideService(CurrentUser, actor()),
+			Effect.provide(Handlers),
+			Effect.catchCause(cause =>
+				Effect.succeed({ ok: false as const, message: toolMessageOf(cause) }),
+			),
+		),
+	)
+
+// A refused call must not read as an empty answer. Everything below goes through
+// here, so a refusal fails the test by its own words rather than as a row that
+// never arrived.
+const resultOf = (outcome: Outcome): Record<string, unknown> => {
+	if (!outcome.ok) throw new Error(outcome.message)
+	return outcome.result ?? {}
+}
+
+const rowsOf = (outcome: Outcome, key: string): ReadonlyArray<unknown> => {
+	const value = resultOf(outcome)[key]
+	return Array.isArray(value) ? value : []
+}
+
+const peopleAdded = (outcome: Outcome): number =>
+	Number(resultOf(outcome)['contacts_added'])
+
+const createdSlug = (outcome: Outcome): string =>
+	String((rowsOf(outcome, 'created')[0] as { slug?: unknown }).slug)
+
+// Read straight from the table rather than from what the tool answered: the point
+// is what is on file for somebody to open, not what the call said it did.
+const peopleOn = async (
+	slug: string,
+): Promise<ReadonlyArray<{ name: string; role: string | null }>> => {
+	const found = await pool.query<{ name: string; role: string | null }>(
+		`SELECT c.name, c.role FROM contacts c
+			JOIN companies co ON co.id = c.company_id
+			WHERE co.organization_id = $1 AND co.slug = $2 AND c.deleted_at IS NULL
+			ORDER BY c.name`,
+		[org.id, slug],
+	)
+	return found.rows
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+	runtime = makeRuntime()
+	const o = await pool.query<Org>(
+		`SELECT id, name, slug FROM organization WHERE slug = 'taller' LIMIT 1`,
+	)
+	const row = o.rows[0]
+	if (!row) throw new Error("taller org missing — run 'pnpm cli seed'")
+	org = row
+	const m = await pool.query<{ userId: string }>(
+		'SELECT "userId" FROM member WHERE "organizationId" = $1 LIMIT 1',
+		[org.id],
+	)
+	actorId = m.rows[0]!.userId
+})
+
+afterAll(async () => {
+	await pool.query(
+		`DELETE FROM contacts WHERE company_id IN (
+			SELECT id FROM companies WHERE name LIKE $1
+		)`,
+		[`%${MARKER}%`],
+	)
+	await pool.query('DELETE FROM companies WHERE name LIKE $1', [`%${MARKER}%`])
+	await runtime.dispose()
+	await pool.end()
+})
+
+describe('create_companies — the people a company brings with it', () => {
+	describe('when a new company is offered with the people its pages name', () => {
+		it('should write them as contacts carrying their job titles', async () => {
+			// GIVEN a company nobody has yet, offered with two people read off its
+			// own team page
+			const name = `Egein Enginyeria ${MARKER}`
+
+			// WHEN it is created in one call
+			const result = await createCompanies([
+				{
+					name,
+					contacts: [
+						{ name: 'David Garrido', role: 'CEO - Enginyer Industrial' },
+						{ name: 'Mariona Garrido', role: 'CFO' },
+					],
+				},
+			])
+
+			// THEN the company lands with both of them on it, titles as the page gave
+			// them
+			expect(rowsOf(result, 'created')).toHaveLength(1)
+			expect(peopleAdded(result)).toBe(2)
+			const slug = createdSlug(result)
+			expect(await peopleOn(slug)).toEqual([
+				{ name: 'David Garrido', role: 'CEO - Enginyer Industrial' },
+				{ name: 'Mariona Garrido', role: 'CFO' },
+			])
+		})
+
+		it('should leave the part they play in a purchase unsaid', async () => {
+			// GIVEN a company offered with somebody who has a job title
+			const name = `Fusteria Cap Buying ${MARKER}`
+
+			// WHEN it is created
+			const result = await createCompanies([
+				{ name, contacts: [{ name: 'Rosa López', role: 'Enginyera' }] },
+			])
+
+			// THEN nothing is recorded about who holds the budget. A page gives a job
+			// title and no more, and a guess here is read later as somebody's finding
+			const slug = createdSlug(result)
+			const buyingRoles = await pool.query<{ buyingRole: string | null }>(
+				`SELECT c.buying_role AS "buyingRole" FROM contacts c
+					JOIN companies co ON co.id = c.company_id
+					WHERE co.organization_id = $1 AND co.slug = $2`,
+				[org.id, slug],
+			)
+			expect(buyingRoles.rows).toEqual([{ buyingRole: null }])
+		})
+	})
+
+	describe('when a job title is offered blank', () => {
+		it('should store no title rather than a blank one', async () => {
+			// GIVEN a person whose title the caller had nothing to put in
+			const name = `Tallers Sense Titol ${MARKER}`
+
+			// WHEN the company is created with them
+			const result = await createCompanies([
+				{ name, contacts: [{ name: 'Joan Sense', role: '   ' }] },
+			])
+
+			// THEN the title is absent, not blank. Blank passes every check for
+			// having a title, so the two spellings stop meaning the same thing
+			const slug = createdSlug(result)
+			expect(await peopleOn(slug)).toEqual([{ name: 'Joan Sense', role: null }])
+		})
+	})
+
+	describe('when the same person is offered twice', () => {
+		it('should write them once, accents and all', async () => {
+			// GIVEN one person written two ways, and a third entry repeating the first
+			const name = `Solà Consultors ${MARKER}`
+
+			// WHEN the company is created
+			const result = await createCompanies([
+				{
+					name,
+					contacts: [
+						{ name: 'Mercè Solà', role: 'Directora' },
+						{ name: 'Merce Sola' },
+						{ name: 'Mercè Solà' },
+					],
+				},
+			])
+
+			// THEN one person is on file. The same person is written with an accent one
+			// time and without it the next, and three rows for one person is worse
+			// than a missing accent
+			expect(peopleAdded(result)).toBe(1)
+			const slug = createdSlug(result)
+			expect(await peopleOn(slug)).toEqual([
+				{ name: 'Mercè Solà', role: 'Directora' },
+			])
+		})
+	})
+
+	describe('when the company is already on file under its registration number', () => {
+		it('should add the newly found people to it and hand back the company', async () => {
+			// GIVEN a company on file, created under one trading name
+			const taxId = `B${String(Date.now()).slice(-8)}`
+			const first = await createCompanies([
+				{
+					name: `Acme ${MARKER}`,
+					taxId,
+					contacts: [{ name: 'Anna Prat', role: 'Gerent' }],
+				},
+			])
+			const filedUnder = createdSlug(first)
+
+			// WHEN the same firm arrives again under a different trading name — a
+			// different web address — with somebody new on it
+			const second = await createCompanies([
+				{
+					name: `Acme Logistics SL ${MARKER}`,
+					taxId,
+					contacts: [
+						{ name: 'Anna Prat', role: 'Gerent' },
+						{ name: 'Pere Nou', role: "Cap d'obres" },
+					],
+				},
+			])
+
+			// THEN no second company is written, the new person lands on the one
+			// already here, and the one already on it is not written again
+			expect(rowsOf(second, 'created')).toHaveLength(0)
+			expect(peopleAdded(second)).toBe(1)
+			expect(await peopleOn(filedUnder)).toEqual([
+				{ name: 'Anna Prat', role: 'Gerent' },
+				{ name: 'Pere Nou', role: "Cap d'obres" },
+			])
+
+			// AND the skip carries the company itself. The slug reported is the one
+			// that was sent, which on a number match is not the one the company is
+			// filed under — so without the company there is nothing to look up
+			const skipped = rowsOf(second, 'skipped')
+			expect(skipped).toHaveLength(1)
+			const skip = skipped[0] as {
+				slug?: unknown
+				matched_on?: unknown
+				company?: { slug?: unknown; id?: unknown }
+			}
+			expect(skip.matched_on).toBe('tax_id')
+			expect(skip.company?.slug).toBe(filedUnder)
+			expect(skip.slug).not.toBe(filedUnder)
+			expect(typeof skip.company?.id).toBe('string')
+		})
+	})
+
+	describe('when a company is already on file under the same web address', () => {
+		it('should write nobody onto it and still hand it back', async () => {
+			// GIVEN a company on file with one person
+			const name = `Talleres Garcia ${MARKER}`
+			const first = await createCompanies([
+				{
+					name,
+					location: 'Girona',
+					contacts: [{ name: 'Jordi Garcia', role: 'Propietari' }],
+				},
+			])
+			const filedUnder = createdSlug(first)
+
+			// WHEN a company of the same name somewhere else is sent, with its own
+			// people
+			const second = await createCompanies([
+				{
+					name,
+					location: 'Sevilla',
+					contacts: [{ name: 'Lucía Ramos', role: 'Administradora' }],
+				},
+			])
+
+			// THEN nobody is written. A web address is folded from the name, so two
+			// unrelated firms reduce to one — and writing here would file Sevilla's
+			// people under Girona's company and report it as done
+			expect(rowsOf(second, 'created')).toHaveLength(0)
+			expect(peopleAdded(second)).toBe(0)
+			expect(await peopleOn(filedUnder)).toEqual([
+				{ name: 'Jordi Garcia', role: 'Propietari' },
+			])
+
+			// AND the caller is handed the company it collided with, so it can see
+			// for itself that this is a different firm
+			const skip = rowsOf(second, 'skipped')[0] as {
+				matched_on?: unknown
+				company?: { slug?: unknown; location?: unknown }
+			}
+			expect(skip.matched_on).toBe('slug')
+			expect(skip.company?.slug).toBe(filedUnder)
+			expect(skip.company?.location).toBe('Girona')
+		})
+	})
+
+	describe('when one firm appears twice in a call under its own number', () => {
+		it("should take the second entry's people onto the first", async () => {
+			// GIVEN one firm sent twice in a single list — the same name, so the same
+			// web address — carrying its registration number both times, with a
+			// different person read off each page
+			const taxId = `B${String(Date.now()).slice(-8)}`
+			const name = `Doble Registre ${MARKER}`
+
+			// WHEN the batch is created
+			const result = await createCompanies([
+				{
+					name,
+					taxId,
+					contacts: [{ name: 'Primera Persona', role: 'Gerent' }],
+				},
+				{ name, taxId, contacts: [{ name: 'Segona Persona', role: 'Tècnic' }] },
+			])
+
+			// THEN one company lands carrying both people. The number settles that the
+			// two entries are one firm, so the second entry's people are its people —
+			// reading the web address first would call this a repeat and lose them
+			expect(rowsOf(result, 'created')).toHaveLength(1)
+			expect(peopleAdded(result)).toBe(2)
+			const slug = createdSlug(result)
+			expect(await peopleOn(slug)).toEqual([
+				{ name: 'Primera Persona', role: 'Gerent' },
+				{ name: 'Segona Persona', role: 'Tècnic' },
+			])
+			const skip = rowsOf(result, 'skipped')[0] as { matched_on?: unknown }
+			expect(skip.matched_on).toBe('tax_id_in_request')
+		})
+	})
+
+	describe('when a company appears twice in one call', () => {
+		it("should keep the first entry's people and count them once", async () => {
+			// GIVEN the same company twice in one list, each time with one person
+			const name = `Dues Vegades ${MARKER}`
+
+			// WHEN the batch is created
+			const result = await createCompanies([
+				{ name, contacts: [{ name: 'Primer Nom', role: 'Gerent' }] },
+				{ name, contacts: [{ name: 'Segon Nom', role: 'Tècnic' }] },
+			])
+
+			// THEN one company lands with the first entry's person. The second is a
+			// mistake in the list, and its web address is the only thing saying the
+			// two entries are one company
+			expect(rowsOf(result, 'created')).toHaveLength(1)
+			expect(peopleAdded(result)).toBe(1)
+			const slug = createdSlug(result)
+			expect(await peopleOn(slug)).toEqual([
+				{ name: 'Primer Nom', role: 'Gerent' },
+			])
+			const skip = rowsOf(result, 'skipped')[0] as { matched_on?: unknown }
+			expect(skip.matched_on).toBe('slug_in_request')
+		})
+	})
+})

--- a/apps/server/src/mcp/tools/contact-job-title.integration.test.ts
+++ b/apps/server/src/mcp/tools/contact-job-title.integration.test.ts
@@ -1,0 +1,208 @@
+// Exercises create_contact and update_contact through the real toolkit handlers,
+// inside the same org RLS scope (`enterOrgScope`) the /mcp middleware applies.
+//
+// What it pins is the one way a job title is absent. A form clears the box and
+// sends blank, a caller with nothing to put there leaves the field out, and a
+// caller taking a wrong title back off sends null — three ways of saying the
+// same thing, which the column must not keep three ways. Only a real database
+// can show what was written down. Requires $DATABASE_URL.
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer, ManagedRuntime, Stream } from 'effect'
+import type { Tool } from 'effect/unstable/ai'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import type { CurrentOrg } from '@batuda/controllers'
+
+import { PgLive } from '../../db/client'
+import { EnvVars } from '../../lib/env'
+import { enterOrgScope } from '../../middleware/org'
+import { applyTestEnv } from '../../test-env'
+import { ContactHandlersLive, ContactTools } from './contacts'
+
+applyTestEnv()
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+// Namespaces every row this suite creates so cleanup never touches seed data.
+const MARKER = `title-verify-${randomUUID()}-`
+
+type Org = { id: string; name: string; slug: string }
+type Tools = typeof ContactTools.tools
+
+const makeRuntime = () =>
+	ManagedRuntime.make(PgLive.pipe(Layer.provide(EnvVars.layer)))
+
+let pool: pg.Pool
+let runtime: ReturnType<typeof makeRuntime>
+let org: Org
+let ownerId: string
+let companyId: string
+
+const callInOrg = <A, E>(
+	body: Effect.Effect<A, E, CurrentOrg | SqlClient.SqlClient>,
+): Promise<A> =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			return yield* enterOrgScope(sql, { org, userId: ownerId })(body)
+		}),
+	)
+
+const runTool = <K extends 'create_contact' | 'update_contact'>(
+	name: K,
+	params: Tool.Parameters<Tools[K]>,
+): Promise<{ readonly id: string }> =>
+	callInOrg(
+		Effect.gen(function* () {
+			const toolkit = yield* ContactTools
+			const stream = yield* toolkit.handle(name, params)
+			const [first] = yield* Stream.runCollect(stream)
+			if (first === undefined) return yield* Effect.die(new Error('no result'))
+			return first.result as { readonly id: string }
+		}).pipe(Effect.provide(ContactHandlersLive)),
+	)
+
+// Read from the table rather than from what the tool answered: the question is
+// what a later reader of this column will find.
+const titleOf = async (id: string): Promise<string | null> => {
+	const found = await pool.query<{ role: string | null }>(
+		'SELECT role FROM contacts WHERE id = $1::uuid',
+		[id],
+	)
+	return found.rows[0]?.role ?? null
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL, max: 4 })
+	await pool.query('GRANT app_user TO CURRENT_USER')
+	runtime = makeRuntime()
+
+	const found = await pool.query<Org>(
+		'SELECT id, name, slug FROM organization WHERE slug = $1 LIMIT 1',
+		['taller'],
+	)
+	if (!found.rows[0])
+		throw new Error(
+			"taller org missing — run 'pnpm cli db reset && pnpm cli seed'",
+		)
+	org = found.rows[0]
+
+	const member = await pool.query<{ userId: string }>(
+		'SELECT "userId" FROM member WHERE "organizationId" = $1 LIMIT 1',
+		[org.id],
+	)
+	if (!member.rows[0])
+		throw new Error("taller has no members — run 'pnpm cli seed'")
+	ownerId = member.rows[0].userId
+
+	const c = await pool.query<{ id: string }>(
+		`INSERT INTO companies (organization_id, slug, name)
+		 VALUES ($1, $2, $3) RETURNING id`,
+		[org.id, `${MARKER}co`, `${MARKER}Fusteria`],
+	)
+	companyId = c.rows[0]!.id
+}, 30_000)
+
+afterAll(async () => {
+	await pool.query('DELETE FROM contacts WHERE name LIKE $1', [`${MARKER}%`])
+	await pool.query('DELETE FROM companies WHERE slug = $1', [`${MARKER}co`])
+	await runtime.dispose()
+	await pool.end()
+})
+
+describe('the job title on a person', () => {
+	describe('when somebody is created with no title at all', () => {
+		it('should store nothing rather than a blank', async () => {
+			// GIVEN a caller that has a name and no title
+			// WHEN the person is created
+			const created = await runTool('create_contact', {
+				company_id: companyId,
+				name: `${MARKER}No Title`,
+			})
+
+			// THEN the column holds nothing. Blank would pass every check for having
+			// a title, so the absence would stop reading as an absence
+			expect(await titleOf(created.id)).toBeNull()
+		})
+	})
+
+	describe('when somebody is created with a title that is only spaces', () => {
+		it('should store nothing rather than the spaces', async () => {
+			// GIVEN a title that looks filled in and says nothing
+			// WHEN the person is created
+			const created = await runTool('create_contact', {
+				company_id: companyId,
+				name: `${MARKER}Spaces`,
+				role: '   ',
+			})
+
+			// THEN it reads the same as never having been given one
+			expect(await titleOf(created.id)).toBeNull()
+		})
+	})
+
+	describe('when a title is taken back off', () => {
+		it('should store nothing, and leave the name alone', async () => {
+			// GIVEN somebody on file with a title
+			const created = await runTool('create_contact', {
+				company_id: companyId,
+				name: `${MARKER}Wrong Title`,
+				role: 'Cap de compres',
+			})
+			expect(await titleOf(created.id)).toBe('Cap de compres')
+
+			// WHEN the title turns out to be wrong and is cleared
+			await runTool('update_contact', { id: created.id, role: null })
+
+			// THEN it is gone — a title can be withdrawn, not only replaced
+			expect(await titleOf(created.id)).toBeNull()
+			const still = await pool.query<{ name: string }>(
+				'SELECT name FROM contacts WHERE id = $1::uuid',
+				[created.id],
+			)
+			expect(still.rows[0]?.name).toBe(`${MARKER}Wrong Title`)
+		})
+	})
+
+	describe('when a title is sent blank on an update', () => {
+		it('should store nothing rather than a blank', async () => {
+			// GIVEN somebody on file with a title
+			const created = await runTool('create_contact', {
+				company_id: companyId,
+				name: `${MARKER}Cleared`,
+				role: 'Gerent',
+			})
+
+			// WHEN a caller sends the emptied box straight through
+			await runTool('update_contact', { id: created.id, role: '' })
+
+			// THEN it lands as nothing, the same as null: a form that clears a box and
+			// a caller that says null mean one thing
+			expect(await titleOf(created.id)).toBeNull()
+		})
+	})
+
+	describe('when an update names everything but the title', () => {
+		it('should leave the title alone', async () => {
+			// GIVEN somebody on file with a title
+			const created = await runTool('create_contact', {
+				company_id: companyId,
+				name: `${MARKER}Untouched`,
+				role: 'Enginyera',
+			})
+
+			// WHEN something else about them changes
+			await runTool('update_contact', {
+				id: created.id,
+				name: `${MARKER}Untouched Renamed`,
+			})
+
+			// THEN the title is still there. Leaving a field out means "don't touch",
+			// and treating it as a clear would wipe a title on every unrelated edit
+			expect(await titleOf(created.id)).toBe('Enginyera')
+		})
+	})
+})

--- a/apps/server/src/mcp/tools/contacts.ts
+++ b/apps/server/src/mcp/tools/contacts.ts
@@ -11,6 +11,7 @@ import {
 	Contact,
 	ContactChannel,
 	HandSetVerificationVerdict,
+	jobTitleOrNothing,
 } from '@batuda/domain'
 
 import {
@@ -78,7 +79,9 @@ const CreateContact = Tool.make('create_contact', {
 				'The branch this person works at, when the company has more than one and it is known which. Leave it out for someone who works for the company at large or moves between its branches — most people, and guessing here is worse than saying nothing.',
 		}),
 		name: Schema.String,
-		role: Schema.optionalKey(Schema.String),
+		// Null as well as absent: a caller that knows there is no job title says so
+		// the same way here as on update, and the same way the web app does.
+		role: Schema.optionalKey(Schema.NullOr(Schema.String)),
 		channels: Schema.optionalKey(Schema.Array(ChannelInput)),
 	}),
 	success: ContactWithChannels,
@@ -98,7 +101,10 @@ const UpdateContact = Tool.make('update_contact', {
 				'The branch this person works at, when the company has more than one and it is known which. Leave it out for someone who works for the company at large or moves between its branches — most people, and guessing here is worse than saying nothing. Pass null to clear a branch somebody no longer works at; leaving it out changes nothing.',
 		}),
 		name: Schema.optionalKey(Schema.String),
-		role: Schema.optionalKey(Schema.String),
+		role: Schema.optionalKey(Schema.NullOr(Schema.String)).annotate({
+			description:
+				"This person's job title, as they or their company give it. Pass null to take off a title that turned out to be wrong or is no longer theirs; leaving it out changes nothing.",
+		}),
 		channels: Schema.optionalKey(Schema.Array(ChannelInput)),
 		clear_email_suppression: Schema.optionalKey(Schema.Boolean),
 	}),
@@ -218,6 +224,7 @@ export const ContactHandlersLive = ContactTools.toLayer(
 						companyId: company_id,
 						siteId: siteId ?? null,
 						...fields,
+						role: jobTitleOrNothing(fields.role),
 					})} RETURNING *`
 					const contact = rows[0] as { id: string }
 					if (channels && channels.length > 0) {
@@ -274,6 +281,11 @@ export const ContactHandlersLive = ContactTools.toLayer(
 						// Only when named: leaving it out means "don't touch", which is
 						// what a caller changing only a phone number expects.
 						...(siteId === undefined ? {} : { siteId }),
+						// Named and left blank is a title taken off, which is not the same
+						// as saying nothing about it.
+						...(fields.role === undefined
+							? {}
+							: { role: jobTitleOrNothing(fields.role) }),
 						updatedAt: DateTime.toDateUtc(DateTime.nowUnsafe()),
 					})} WHERE id = ${id} RETURNING *`
 					if (clear_email_suppression)

--- a/apps/server/src/services/companies-create-tax-id.integration.test.ts
+++ b/apps/server/src/services/companies-create-tax-id.integration.test.ts
@@ -40,7 +40,9 @@ const createMany = (items: ReadonlyArray<Record<string, unknown>>) =>
 		Effect.gen(function* () {
 			const sql = yield* SqlClient.SqlClient
 			const service = yield* CompanyService
-			return yield* enterOrgScope(sql, { org })(service.createMany(items))
+			return yield* enterOrgScope(sql, { org })(
+				service.createMany(items.map(company => ({ company, contacts: [] }))),
+			)
 		}).pipe(Effect.orDie),
 	)
 
@@ -97,9 +99,14 @@ describe('CompanyService.createMany deduping on the registration number', () => 
 			// AND the second is reported as a repeat inside this very call, by its
 			// number rather than its slug — which is the whole point: its slug was new,
 			// and it was never on file before this call either
-			expect(batch.skipped).toStrictEqual([
-				{ slug: `acme-logistics-${suffix}`, matchedOn: 'taxIdInRequest' },
-			])
+			expect(batch.skipped).toHaveLength(1)
+			expect(batch.skipped[0]?.slug).toBe(`acme-logistics-${suffix}`)
+			expect(batch.skipped[0]?.matchedOn).toBe('taxIdInRequest')
+
+			// AND it hands back the company it matched — the one this same call wrote
+			// a moment earlier. The slug reported is the one that was sent, which here
+			// is not the address that company is filed under
+			expect(batch.skipped[0]?.company.slug).toBe(`acme-${suffix}`)
 		})
 	})
 
@@ -116,9 +123,10 @@ describe('CompanyService.createMany deduping on the registration number', () => 
 			// THEN one landed, and the other is reported as the caller having sent the
 			// same slug twice rather than as a company already in the CRM
 			expect(batch.created).toHaveLength(1)
-			expect(batch.skipped).toStrictEqual([
-				{ slug: `dup-${suffix}`, matchedOn: 'slugInRequest' },
-			])
+			expect(batch.skipped).toHaveLength(1)
+			expect(batch.skipped[0]?.slug).toBe(`dup-${suffix}`)
+			expect(batch.skipped[0]?.matchedOn).toBe('slugInRequest')
+			expect(batch.skipped[0]?.company.name).toBe('Dup One')
 		})
 	})
 
@@ -181,9 +189,15 @@ describe('CompanyService.createMany telling a company already on file from one s
 			// THEN nothing new landed, and the report says the number was on file
 			// rather than sent twice — the caller's list was fine
 			expect(second.created).toHaveLength(0)
-			expect(second.skipped).toStrictEqual([
-				{ slug: `prior-trading-${suffix}`, matchedOn: 'taxId' },
-			])
+			expect(second.skipped).toHaveLength(1)
+			expect(second.skipped[0]?.slug).toBe(`prior-trading-${suffix}`)
+			expect(second.skipped[0]?.matchedOn).toBe('taxId')
+
+			// AND the company on file comes back with it. This is the case where the
+			// slug reported cannot be looked up: the firm is filed under the name it
+			// first arrived as, so only the company itself leads anywhere
+			expect(second.skipped[0]?.company.slug).toBe(`prior-${suffix}`)
+			expect(second.skipped[0]?.company.id).toBe(first.created[0]?.id)
 		})
 	})
 
@@ -203,9 +217,10 @@ describe('CompanyService.createMany telling a company already on file from one s
 
 			// THEN the slug is reported as one the CRM already held
 			expect(second.created).toHaveLength(0)
-			expect(second.skipped).toStrictEqual([
-				{ slug: `held-${suffix}`, matchedOn: 'slug' },
-			])
+			expect(second.skipped).toHaveLength(1)
+			expect(second.skipped[0]?.slug).toBe(`held-${suffix}`)
+			expect(second.skipped[0]?.matchedOn).toBe('slug')
+			expect(second.skipped[0]?.company.name).toBe('Held One')
 		})
 	})
 })

--- a/apps/server/src/services/companies-create-with-contacts.integration.test.ts
+++ b/apps/server/src/services/companies-create-with-contacts.integration.test.ts
@@ -1,0 +1,406 @@
+// PgLive reads DATABASE_URL via Config at layer-build time. Default to the
+// integration database so the suite runs without a loaded env.
+process.env['DATABASE_URL'] ??=
+	'postgresql://batuda:batuda@localhost:5433/batuda_it'
+
+import { randomUUID } from 'node:crypto'
+
+import { Effect, Layer, ManagedRuntime } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { PgLive } from '../db/client'
+import { enterOrgScope } from '../middleware/org'
+import { CompanyService } from './companies'
+
+// The real CompanyService.createWithContacts, run against the live database.
+//
+// This is what the one-click handoff from a company search calls, and the two
+// things it has to get right are both invisible to a type check: that offering
+// the same company a second time lands on the one already here rather than
+// making another, and that the people arriving with it are written once.
+
+const DATABASE_URL = process.env['DATABASE_URL'] as string
+
+let pool: pg.Pool
+let org: { readonly id: string; readonly name: string; readonly slug: string }
+const createdIds: string[] = []
+
+const runtime = ManagedRuntime.make(
+	CompanyService.layer.pipe(Layer.provideMerge(PgLive)),
+)
+
+const takeOn = (
+	company: Record<string, unknown>,
+	contacts: ReadonlyArray<{ readonly name: string; readonly role?: string }>,
+) =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient
+			const service = yield* CompanyService
+			return yield* enterOrgScope(sql, { org })(
+				service.createWithContacts({ company, contacts }),
+			)
+		}).pipe(Effect.orDie),
+	)
+
+const peopleOn = async (companyId: string) => {
+	const rows = await pool.query<{ name: string; role: string | null }>(
+		`SELECT name, role FROM contacts WHERE company_id = $1::uuid AND deleted_at IS NULL ORDER BY name`,
+		[companyId],
+	)
+	return rows.rows
+}
+
+beforeAll(async () => {
+	pool = new pg.Pool({ connectionString: DATABASE_URL })
+	await pool.query('GRANT app_user TO CURRENT_USER')
+	const orgs = await pool.query<{ id: string; name: string; slug: string }>(
+		`SELECT id, name, slug FROM organization WHERE slug = $1 LIMIT 1`,
+		['taller'],
+	)
+	const row = orgs.rows[0]
+	if (!row) {
+		throw new Error(
+			"taller org missing — run 'pnpm cli db reset && pnpm cli seed' first",
+		)
+	}
+	org = row
+}, 30_000)
+
+afterAll(async () => {
+	for (const id of createdIds) {
+		await pool.query(`DELETE FROM contacts WHERE company_id = $1::uuid`, [id])
+		await pool.query(`DELETE FROM companies WHERE id = $1::uuid`, [id])
+	}
+	await pool.end()
+	await runtime.dispose()
+})
+
+describe('CompanyService.createWithContacts', () => {
+	describe('when a company arrives with the people its pages named', () => {
+		it('should write both, leaving the part they play in a purchase unsaid', async () => {
+			// GIVEN a company nobody has filed yet, with two people read off its
+			// own team page — one with a title, one without
+			const slug = `egein-${randomUUID().slice(0, 8)}`
+			const result = await takeOn({ name: 'Egein', slug }, [
+				{ name: 'David Garrido', role: 'CEO - Enginyer Industrial' },
+				{ name: 'Mariona Garrido' },
+			])
+			createdIds.push(result.company.id)
+
+			// THEN the company lands with both people
+			expect(result.created).toBe(true)
+			expect(result.contactsAdded).toBe(2)
+			const people = await peopleOn(result.company.id)
+			expect(people).toStrictEqual([
+				{ name: 'David Garrido', role: 'CEO - Enginyer Industrial' },
+				{ name: 'Mariona Garrido', role: null },
+			])
+
+			// AND nobody is given a part in the buying decision: a search reads a
+			// job title off a page and cannot know who holds the budget
+			const roles = await pool.query<{ buying_role: string | null }>(
+				`SELECT buying_role FROM contacts WHERE company_id = $1::uuid`,
+				[result.company.id],
+			)
+			expect(roles.rows.every(person => person.buying_role === null)).toBe(true)
+		})
+	})
+
+	describe('when the same prospect is added a second time', () => {
+		it('should land on the company already here rather than make another', async () => {
+			// GIVEN a company already filed from a first click
+			const slug = `serxar-${randomUUID().slice(0, 8)}`
+			const first = await takeOn({ name: 'Serxar', slug }, [
+				{ name: 'Gerard Batlle', role: 'Adjunt Direccio' },
+			])
+			createdIds.push(first.company.id)
+
+			// WHEN the same row is clicked again — which is ordinary, a person
+			// working down a list of fifty loses their place
+			const second = await takeOn({ name: 'Serxar', slug }, [
+				{ name: 'Gerard Batlle', role: 'Adjunt Direccio' },
+			])
+
+			// THEN it is the same company, said plainly, and no second row exists
+			expect(second.created).toBe(false)
+			expect(second.company.id).toBe(first.company.id)
+			const rows = await pool.query(
+				`SELECT id FROM companies WHERE organization_id = $1 AND slug = $2 AND deleted_at IS NULL`,
+				[org.id, slug],
+			)
+			expect(rows.rowCount).toBe(1)
+
+			// AND the person is not written twice
+			expect(second.contactsAdded).toBe(0)
+			expect(await peopleOn(first.company.id)).toHaveLength(1)
+		})
+	})
+
+	describe('when the second click brings somebody the first did not', () => {
+		it('should add only the new person', async () => {
+			// GIVEN a company filed with one person
+			const slug = `bellmas-${randomUUID().slice(0, 8)}`
+			const first = await takeOn({ name: 'Bellmas', slug }, [
+				{ name: 'Laura Bellmas' },
+			])
+			createdIds.push(first.company.id)
+
+			// WHEN a later run names a second person alongside the first
+			const second = await takeOn({ name: 'Bellmas', slug }, [
+				{ name: 'Laura Bellmas' },
+				{ name: 'Marc Puig', role: 'Gerent' },
+			])
+
+			// THEN only the newcomer is written
+			expect(second.contactsAdded).toBe(1)
+			expect((await peopleOn(first.company.id)).map(p => p.name)).toStrictEqual(
+				['Laura Bellmas', 'Marc Puig'],
+			)
+		})
+	})
+
+	describe('when a person is written with an accent one time and without it the next', () => {
+		it('should treat them as one person', async () => {
+			// GIVEN a company whose director was filed without her accents
+			const slug = `girona-${randomUUID().slice(0, 8)}`
+			const first = await takeOn({ name: 'Girona Tec', slug }, [
+				{ name: 'Merce Sola' },
+			])
+			createdIds.push(first.company.id)
+
+			// WHEN a later run spells her properly
+			const second = await takeOn({ name: 'Girona Tec', slug }, [
+				{ name: 'Mercè Solà' },
+			])
+
+			// THEN she is not filed twice: the same person spelled two ways is one
+			// person, and two rows would be two people to call
+			expect(second.contactsAdded).toBe(0)
+			expect(await peopleOn(first.company.id)).toHaveLength(1)
+		})
+	})
+
+	describe('when the same firm arrives under a different trading name', () => {
+		it('should recognise it by the number it is registered under', async () => {
+			// GIVEN a company filed with its registration number
+			const digits = `${Date.now()}`.slice(-8)
+			const first = await takeOn(
+				{
+					name: 'Especialidades Geotecnicas SL',
+					slug: `especialidades-${randomUUID().slice(0, 8)}`,
+					taxId: `B-${digits}`,
+				},
+				[],
+			)
+			createdIds.push(first.company.id)
+
+			// WHEN the same firm turns up under the name it trades as, which gives
+			// a different web address entirely
+			const second = await takeOn(
+				{
+					name: 'Egein Group',
+					slug: `egein-group-${randomUUID().slice(0, 8)}`,
+					taxId: `b${digits}`,
+				},
+				[{ name: 'David Garrido', role: 'CEO' }],
+			)
+
+			// THEN it is the company already here: the name and the web address
+			// both changed, the registration did not
+			expect(second.created).toBe(false)
+			expect(second.company.id).toBe(first.company.id)
+
+			// AND its people land on the company that was already filed
+			expect(second.contactsAdded).toBe(1)
+			expect((await peopleOn(first.company.id)).map(p => p.name)).toStrictEqual(
+				['David Garrido'],
+			)
+		})
+	})
+
+	describe('when the two identities point at different companies', () => {
+		it('should answer with the one the number names, not the name', async () => {
+			// GIVEN two companies already on file: one whose registration number
+			// this prospect carries, and a different one that happens to reduce to
+			// the same web address the prospect's name would
+			const digits = `${Date.now()}`.slice(-8)
+			const sharedSlug = `talleres-garcia-${randomUUID().slice(0, 8)}`
+			const byNumber = await takeOn(
+				{
+					name: 'Egein SL',
+					slug: `egein-sl-${randomUUID().slice(0, 8)}`,
+					taxId: `B-${digits}`,
+				},
+				[],
+			)
+			createdIds.push(byNumber.company.id)
+			const byName = await takeOn(
+				{ name: 'Talleres Garcia', slug: sharedSlug },
+				[],
+			)
+			createdIds.push(byName.company.id)
+
+			// WHEN a prospect arrives carrying the first one's number and the
+			// second one's address
+			const result = await takeOn(
+				{ name: 'Talleres Garcia', slug: sharedSlug, taxId: `b${digits}` },
+				[],
+			)
+
+			// THEN the number decides. A name is written differently every time and
+			// two unrelated firms can reduce to one address; a registration cannot.
+			expect(result.created).toBe(false)
+			expect(result.company.id).toBe(byNumber.company.id)
+		})
+	})
+
+	describe('when a different firm reduces to the same address', () => {
+		it('should keep them apart rather than file one under the other', async () => {
+			// GIVEN a company on file under a registration number of its own
+			const slug = `talleres-garcia-${randomUUID().slice(0, 8)}`
+			const digits = `${Date.now()}`.slice(-8)
+			const first = await takeOn(
+				{ name: 'Talleres Garcia', slug, taxId: `B-${digits}` },
+				[{ name: 'Joan Garcia', role: 'Gerent' }],
+			)
+			createdIds.push(first.company.id)
+
+			// WHEN a genuinely different firm arrives whose name folds to the same
+			// address — accents dropped, long names cut short — carrying its own
+			// and different number
+			const second = await takeOn(
+				{ name: 'Talleres García', slug, taxId: `B-${Number(digits) + 1}` },
+				[{ name: 'Marta Puig', role: 'Directora' }],
+			)
+			createdIds.push(second.company.id)
+
+			// THEN it is its own company, not the first one wearing a second set of
+			// people: two numbers mean two firms, whatever the address says
+			expect(second.created).toBe(true)
+			expect(second.company.id).not.toBe(first.company.id)
+
+			// AND neither one has been given the other's people
+			expect((await peopleOn(first.company.id)).map(p => p.name)).toStrictEqual(
+				['Joan Garcia'],
+			)
+			expect(
+				(await peopleOn(second.company.id)).map(p => p.name),
+			).toStrictEqual(['Marta Puig'])
+		})
+
+		it('should still answer to its own number when offered again', async () => {
+			// GIVEN the firm that had to take an address of its own
+			const slug = `metalls-${randomUUID().slice(0, 8)}`
+			const digits = `${Date.now()}`.slice(-7)
+			const holder = await takeOn(
+				{ name: 'Metalls', slug, taxId: `A-${digits}` },
+				[],
+			)
+			createdIds.push(holder.company.id)
+			const other = await takeOn(
+				{ name: 'Metalls', slug, taxId: `A-${Number(digits) + 1}` },
+				[],
+			)
+			createdIds.push(other.company.id)
+
+			// WHEN it is offered a third time, address clash and all
+			const again = await takeOn(
+				{ name: 'Metalls', slug, taxId: `A-${Number(digits) + 1}` },
+				[{ name: 'Nou Contacte' }],
+			)
+
+			// THEN it lands on itself rather than making a third row: the address
+			// still clashes, but the number settles it
+			expect(again.created).toBe(false)
+			expect(again.company.id).toBe(other.company.id)
+			expect(again.contactsAdded).toBe(1)
+		})
+	})
+
+	describe('when a company already here is offered its registration number', () => {
+		it('should write the number down rather than drop it', async () => {
+			// GIVEN a company filed from an earlier click, before any run had read
+			// its number
+			const slug = `enigest-${randomUUID().slice(0, 8)}`
+			const first = await takeOn({ name: 'Enigest', slug }, [])
+			createdIds.push(first.company.id)
+			expect(first.company.taxId).toBeNull()
+
+			// WHEN a later run reads the number off its registry page and the
+			// person clicks again
+			const digits = `${Date.now()}`.slice(-8)
+			const second = await takeOn(
+				{ name: 'Enigest', slug, taxId: `B-${digits}` },
+				[],
+			)
+
+			// THEN it lands on the company, and the number is kept: without it the
+			// same firm arriving later under another name would be filed twice
+			expect(second.created).toBe(false)
+			expect(second.company.id).toBe(first.company.id)
+			const held = await pool.query<{ tax_id: string | null }>(
+				`SELECT tax_id FROM companies WHERE id = $1::uuid`,
+				[first.company.id],
+			)
+			expect(held.rows[0]?.tax_id).toBe(`B-${digits}`)
+		})
+	})
+
+	describe('when two firms share an address and neither has a number', () => {
+		it('should keep them apart and still recognise each one again', async () => {
+			// GIVEN one firm on file, in Girona, with no registration number — which
+			// is the ordinary case, since the register is rarely reachable
+			const slug = `talleres-vidal-${randomUUID().slice(0, 8)}`
+			const girona = await takeOn(
+				{ name: 'Talleres Vidal', slug, location: 'Girona' },
+				[{ name: 'Joan Vidal' }],
+			)
+			createdIds.push(girona.company.id)
+
+			// WHEN a different firm of the same name, in Sevilla, is offered
+			const sevilla = await takeOn(
+				{ name: 'Talleres Vidal', slug, location: 'Sevilla' },
+				[{ name: 'Marta Ruiz' }],
+			)
+			createdIds.push(sevilla.company.id)
+
+			// THEN it is its own company: the place says they are not the same firm,
+			// and folding them together would put Sevilla's people on Girona's record
+			expect(sevilla.created).toBe(true)
+			expect(sevilla.company.id).not.toBe(girona.company.id)
+
+			// AND offering the Sevilla one again lands on itself rather than filing
+			// a third — the address it took is its own place, not a fresh guess
+			const again = await takeOn(
+				{ name: 'Talleres Vidal', slug, location: 'Sevilla' },
+				[{ name: 'Marta Ruiz' }, { name: 'Pau Gil' }],
+			)
+			expect(again.created).toBe(false)
+			expect(again.company.id).toBe(sevilla.company.id)
+			expect(again.contactsAdded).toBe(1)
+
+			// AND neither company wears the other's people
+			expect(
+				(await peopleOn(girona.company.id)).map(p => p.name),
+			).toStrictEqual(['Joan Vidal'])
+			expect(
+				(await peopleOn(sevilla.company.id)).map(p => p.name),
+			).toStrictEqual(['Marta Ruiz', 'Pau Gil'])
+		})
+	})
+
+	describe('when a company arrives with nobody', () => {
+		it('should file it and report no people', async () => {
+			const slug = `quiet-${randomUUID().slice(0, 8)}`
+			const result = await takeOn({ name: 'Quiet SL', slug }, [])
+			createdIds.push(result.company.id)
+
+			expect(result.created).toBe(true)
+			expect(result.contactsAdded).toBe(0)
+			expect(await peopleOn(result.company.id)).toHaveLength(0)
+		})
+	})
+})

--- a/apps/server/src/services/companies-create-with-contacts.integration.test.ts
+++ b/apps/server/src/services/companies-create-with-contacts.integration.test.ts
@@ -107,6 +107,24 @@ describe('CompanyService.createWithContacts', () => {
 			)
 			expect(roles.rows.every(person => person.buying_role === null)).toBe(true)
 		})
+
+		it('should store a blank job title as no job title', async () => {
+			// GIVEN a person whose title the caller sent as an empty box rather
+			// than leaving the field out
+			const slug = `blanc-${randomUUID().slice(0, 8)}`
+			const result = await takeOn({ name: 'Blanc', slug }, [
+				{ name: 'Joan Blanc', role: '' },
+				{ name: 'Pau Espai', role: '   ' },
+			])
+			createdIds.push(result.company.id)
+
+			// THEN both read as having no title. A blank one passes every check
+			// for having a title, so it would be quoted back at somebody on a call
+			expect(await peopleOn(result.company.id)).toStrictEqual([
+				{ name: 'Joan Blanc', role: null },
+				{ name: 'Pau Espai', role: null },
+			])
+		})
 	})
 
 	describe('when the same prospect is added a second time', () => {

--- a/apps/server/src/services/companies.ts
+++ b/apps/server/src/services/companies.ts
@@ -14,6 +14,7 @@ import {
 	Contact,
 	foldLabel,
 	Interaction,
+	jobTitleOrNothing,
 	normalizeCountry,
 } from '@batuda/domain'
 
@@ -103,6 +104,58 @@ export interface CompanyFilters {
  */
 export const normalizeTaxId = (taxId: string): string =>
 	taxId.replace(/[^A-Za-z0-9]/g, '').toUpperCase()
+
+/**
+ * A person a company search read off the company's own pages: who they are, and
+ * what the page called them. No way of reaching them — an email is either
+ * published, in which case it is already on the company's own channels, or
+ * it is guessed and checked, which costs money for each person.
+ */
+export interface LeadPerson {
+	readonly name: string
+	readonly role?: string | null | undefined
+}
+
+/**
+ * Write the people offered with a company onto it, and say how many were new.
+ *
+ * Anyone the company already has is left alone: the same person is found again
+ * every time the company is, and a name written with an accent one time and
+ * without it the next is one person, not two. Their part in a purchase is not
+ * set — a page gives a job title and nothing about who holds the budget.
+ */
+const writeContacts = (
+	sql: SqlClient.SqlClient,
+	organizationId: string,
+	companyId: string,
+	people: ReadonlyArray<LeadPerson>,
+) =>
+	Effect.gen(function* () {
+		if (people.length === 0) return 0
+		const held = yield* sql`
+			SELECT name FROM contacts
+			WHERE organization_id = ${organizationId}
+				AND company_id = ${companyId}
+				AND deleted_at IS NULL
+		`
+		const heldNames = new Set(
+			held.map(person => foldLabel(String(person['name']))),
+		)
+		let added = 0
+		for (const person of people) {
+			const key = foldLabel(person.name)
+			if (key === '' || heldNames.has(key)) continue
+			heldNames.add(key)
+			yield* sql`INSERT INTO contacts ${sql.insert({
+				organizationId,
+				companyId,
+				name: person.name,
+				role: jobTitleOrNothing(person.role),
+			})}`
+			added++
+		}
+		return added
+	})
 
 /** A filter that offers a menu of its values, each with how many it would find. */
 export type CompanyFacetKey = 'country' | 'industry' | 'tags' | 'fitVerdict'
@@ -519,17 +572,11 @@ export class CompanyService extends Context.Service<CompanyService>()(
 				 * it is registered under, which catches the same firm arriving under
 				 * a different trading name.
 				 *
-				 * The people land on whichever company answered, new or already
-				 * here, and anyone it already has is left alone. Their part in a
-				 * purchase is not set: a search reads a job title off a page and has
-				 * no way of knowing who holds the budget.
+				 * The people land on whichever company answered, new or already here.
 				 */
 				createWithContacts: (args: {
 					readonly company: Record<string, unknown>
-					readonly contacts: ReadonlyArray<{
-						readonly name: string
-						readonly role?: string | undefined
-					}>
+					readonly contacts: ReadonlyArray<LeadPerson>
 				}) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
@@ -703,31 +750,12 @@ export class CompanyService extends Context.Service<CompanyService>()(
 							`
 						}
 
-						const held = yield* sql`
-							SELECT name FROM contacts
-							WHERE organization_id = ${currentOrg.id}
-								AND company_id = ${companyId}
-								AND deleted_at IS NULL
-						`
-						// Folded before comparing, so the same person written with an
-						// accent one time and without it the next is one person.
-						const heldNames = new Set(
-							held.map(person => foldLabel(String(person['name']))),
+						const contactsAdded = yield* writeContacts(
+							sql,
+							currentOrg.id,
+							companyId,
+							args.contacts,
 						)
-
-						let contactsAdded = 0
-						for (const person of args.contacts) {
-							const key = foldLabel(person.name)
-							if (key === '' || heldNames.has(key)) continue
-							heldNames.add(key)
-							yield* sql`INSERT INTO contacts ${sql.insert({
-								organizationId: currentOrg.id,
-								companyId,
-								name: person.name,
-								role: person.role ?? null,
-							})}`
-							contactsAdded++
-						}
 
 						return {
 							company: yield* Schema.decodeUnknownEffect(Company)(row),
@@ -864,10 +892,20 @@ export class CompanyService extends Context.Service<CompanyService>()(
 				// The lookup runs inside the same transaction as the inserts, so a number
 				// repeated twice within one batch is caught on the second one too.
 				//
-				// Both keys are reported back by what matched, so a caller told a company
-				// was left out can tell "you already have this slug" from "you already
-				// have this company under another name" without guessing.
-				createMany: (items: ReadonlyArray<Record<string, unknown>>) =>
+				// Both keys are reported back by what matched, and with the company that
+				// matched, so a caller told a company was left out can tell "you already
+				// have this slug" from "you already have this company under another name"
+				// without guessing — and is holding the company rather than a name to go
+				// and look up.
+				//
+				// The people offered with a company land on it where the same firm is
+				// established: this call created it, or its registration number matched.
+				createMany: (
+					items: ReadonlyArray<{
+						readonly company: Record<string, unknown>
+						readonly contacts: ReadonlyArray<LeadPerson>
+					}>,
+				) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
 						// Checked before anything lands: the batch is one transaction, so
@@ -875,7 +913,7 @@ export class CompanyService extends Context.Service<CompanyService>()(
 						// most of the list and leaving the caller to work out which.
 						yield* requireOrgMembers(
 							sql,
-							items.map(item => item['ownerId']),
+							items.map(item => item.company['ownerId']),
 						)
 						const inserted: Array<unknown> = []
 						const skipped: Array<{
@@ -885,31 +923,52 @@ export class CompanyService extends Context.Service<CompanyService>()(
 								| 'taxId'
 								| 'slugInRequest'
 								| 'taxIdInRequest'
+							readonly company: Schema.Schema.Type<typeof Company>
 						}> = []
-						// What this very call has written so far. Without it a repeat inside
-						// one request reads exactly like a company that had been on file for
-						// a year: the slug conflict and the tax-id lookup below both find the
-						// row this same call inserted a moment earlier, and the caller is told
-						// it already existed.
-						const slugsWritten = new Set<string>()
-						const taxIdsWritten = new Set<string>()
-						for (const data of items) {
-							const slug = typeof data['slug'] === 'string' ? data['slug'] : ''
+						let contactsAdded = 0
+						// What this very call has written so far, and the row it wrote.
+						// Without it a repeat inside one request reads exactly like a company
+						// that had been on file for a year: the slug conflict and the tax-id
+						// lookup below both find the row this same call inserted a moment
+						// earlier, and the caller is told it already existed.
+						const slugsWritten = new Map<string, unknown>()
+						const taxIdsWritten = new Map<string, unknown>()
+						// Bound once: the org id and the company id sit side by side in the call
+						// below, and swapping them files people under the wrong company silently.
+						const addPeople = (
+							companyId: string,
+							people: ReadonlyArray<LeadPerson>,
+						) => writeContacts(sql, currentOrg.id, companyId, people)
+						for (const item of items) {
+							const companyFields = item.company
+							const slug =
+								typeof companyFields['slug'] === 'string'
+									? companyFields['slug']
+									: ''
 							const taxId =
-								typeof data['taxId'] === 'string' ? data['taxId'] : null
+								typeof companyFields['taxId'] === 'string'
+									? companyFields['taxId']
+									: null
 							const normalizedTaxId =
 								taxId === null ? '' : normalizeTaxId(taxId)
-							if (slugsWritten.has(slug)) {
-								skipped.push({ slug, matchedOn: 'slugInRequest' })
-								continue
-							}
+							// The number is asked first and alone, because it is the surer of the
+							// two: a firm is written down differently every time it is found, and
+							// its registration is not. Checking the web address first would call
+							// one firm sent twice a repeat and drop the second entry's people on
+							// the strength of a folded name.
 							if (normalizedTaxId !== '') {
-								if (taxIdsWritten.has(normalizedTaxId)) {
-									skipped.push({ slug, matchedOn: 'taxIdInRequest' })
+								const sameNumberInBatch = taxIdsWritten.get(normalizedTaxId)
+								if (sameNumberInBatch !== undefined) {
+									const company =
+										yield* Schema.decodeUnknownEffect(Company)(
+											sameNumberInBatch,
+										)
+									contactsAdded += yield* addPeople(company.id, item.contacts)
+									skipped.push({ slug, matchedOn: 'taxIdInRequest', company })
 									continue
 								}
-								const existing = yield* sql`
-									SELECT id FROM companies
+								const sameNumberOnFile = yield* sql`
+									SELECT * FROM companies
 									WHERE organization_id = ${currentOrg.id}
 										-- Live rows only, matching the slug half: a company that
 										-- was deleted has given its identity back, so re-adding it
@@ -921,12 +980,29 @@ export class CompanyService extends Context.Service<CompanyService>()(
 											= ${normalizedTaxId}
 									LIMIT 1
 								`
-								if (existing.length > 0) {
-									skipped.push({ slug, matchedOn: 'taxId' })
+								const registered = sameNumberOnFile[0]
+								if (registered !== undefined) {
+									const company =
+										yield* Schema.decodeUnknownEffect(Company)(registered)
+									contactsAdded += yield* addPeople(company.id, item.contacts)
+									skipped.push({ slug, matchedOn: 'taxId', company })
 									continue
 								}
 							}
-							const split = splitCompanyChannelFields(data)
+							const sameSlugInBatch = slugsWritten.get(slug)
+							if (sameSlugInBatch !== undefined) {
+								// The people offered with it are dropped on purpose: a web address
+								// is folded from the name, so these two entries can be two firms,
+								// and filing one's people under the other is worse than losing them.
+								skipped.push({
+									slug,
+									matchedOn: 'slugInRequest',
+									company:
+										yield* Schema.decodeUnknownEffect(Company)(sameSlugInBatch),
+								})
+								continue
+							}
+							const split = splitCompanyChannelFields(companyFields)
 							// The trade a caller named becomes an entry in the organisation's
 							// own list, so its name and the entry it points at are written
 							// together and can never disagree.
@@ -948,8 +1024,35 @@ export class CompanyService extends Context.Service<CompanyService>()(
 								RETURNING *
 							`
 							const row = rows[0]
-							if (row === undefined) skipped.push({ slug, matchedOn: 'slug' })
-							else {
+							if (row === undefined) {
+								// DO NOTHING says nothing about what is already there, so the
+								// company holding this address is asked for by name. Inside this
+								// transaction the conflict proves a live row has the slug, so
+								// finding none would mean the arbiter and this condition have
+								// drifted apart.
+								const sameSlugOnFile = yield* sql`
+									SELECT * FROM companies
+									WHERE organization_id = ${currentOrg.id}
+										AND deleted_at IS NULL
+										AND slug = ${slug}
+									LIMIT 1
+								`
+								const holder = sameSlugOnFile[0]
+								if (holder === undefined)
+									return yield* Effect.die(
+										new Error(
+											`company insert conflicted on "${slug}" with no live row holding it`,
+										),
+									)
+								// The people offered with it are dropped on purpose, for the same
+								// reason: a web address is folded from the name, so the company
+								// holding it can be a different firm entirely.
+								skipped.push({
+									slug,
+									matchedOn: 'slug',
+									company: yield* Schema.decodeUnknownEffect(Company)(holder),
+								})
+							} else {
 								if (split.channels.length > 0) {
 									yield* writeChannels(
 										sql,
@@ -958,15 +1061,20 @@ export class CompanyService extends Context.Service<CompanyService>()(
 										split.channels,
 									)
 								}
-								slugsWritten.add(slug)
-								if (normalizedTaxId !== '') taxIdsWritten.add(normalizedTaxId)
+								slugsWritten.set(slug, row)
+								if (normalizedTaxId !== '')
+									taxIdsWritten.set(normalizedTaxId, row)
+								contactsAdded += yield* addPeople(
+									String(row['id']),
+									item.contacts,
+								)
 								inserted.push(row)
 							}
 						}
 						const created = yield* Schema.decodeUnknownEffect(
 							Schema.Array(Company),
 						)(inserted)
-						return { created, skipped }
+						return { created, skipped, contactsAdded }
 					}).pipe(sql.withTransaction),
 
 				update: (id: string, data: Record<string, unknown>) =>

--- a/apps/server/src/services/companies.ts
+++ b/apps/server/src/services/companies.ts
@@ -12,6 +12,7 @@ import {
 	Company,
 	type CompanySort,
 	Contact,
+	foldLabel,
 	Interaction,
 	normalizeCountry,
 } from '@batuda/domain'
@@ -507,35 +508,232 @@ export class CompanyService extends Context.Service<CompanyService>()(
 						return yield* Schema.decodeUnknownEffect(Company)(company)
 					}),
 
-				create: (data: Record<string, unknown>) =>
+				/**
+				 * Take a company on, with the people a search read off its pages.
+				 *
+				 * Finds it rather than making a second one when it is already here.
+				 * Sending the same company twice is an ordinary thing to do — a
+				 * person working down a list of fifty loses their place — so two
+				 * identities are checked: the web address the company is filed
+				 * under, which catches the same name arriving again, and the number
+				 * it is registered under, which catches the same firm arriving under
+				 * a different trading name.
+				 *
+				 * The people land on whichever company answered, new or already
+				 * here, and anyone it already has is left alone. Their part in a
+				 * purchase is not set: a search reads a job title off a page and has
+				 * no way of knowing who holds the budget.
+				 */
+				createWithContacts: (args: {
+					readonly company: Record<string, unknown>
+					readonly contacts: ReadonlyArray<{
+						readonly name: string
+						readonly role?: string | undefined
+					}>
+				}) =>
 					Effect.gen(function* () {
 						const currentOrg = yield* CurrentOrg
-						const split = splitCompanyChannelFields(data)
-						// The trade a caller named becomes an entry in the organisation's
-						// own list, so its name and the entry it points at are written
-						// together and can never disagree.
-						const columns = withIndustry(
-							split.columns,
-							yield* industryForWrite(
-								sql,
-								currentOrg.id,
-								split.columns['industry'],
-							),
-						)
-						const rows =
-							yield* sql`INSERT INTO companies ${sql.insert({ ...columns, organizationId: currentOrg.id })} RETURNING *`
-						const row = rows[0]
-						if (row !== undefined && split.channels.length > 0) {
-							yield* writeChannels(
-								sql,
-								currentOrg.id,
-								{ table: 'companies', id: String(row['id']) },
-								split.channels,
+						const slug =
+							typeof args.company['slug'] === 'string'
+								? args.company['slug']
+								: ''
+						const taxId =
+							typeof args.company['taxId'] === 'string'
+								? normalizeTaxId(args.company['taxId'])
+								: ''
+
+						// Live rows only, on both identities. A company that was deleted
+						// has given its identity back, so re-adding it has to land rather
+						// than answer with something nobody can open.
+						//
+						// The number is asked first and alone, because it is the surer of
+						// the two: a firm is written down differently every time it is
+						// found, and its registration is not.
+						const byNumber =
+							taxId === ''
+								? []
+								: yield* sql`
+										SELECT * FROM companies
+										WHERE organization_id = ${currentOrg.id}
+											AND deleted_at IS NULL
+											AND tax_id IS NOT NULL
+											AND upper(regexp_replace(tax_id, '[^A-Za-z0-9]', '', 'g'))
+												= ${taxId}
+										LIMIT 1
+									`
+
+						// Then the web address the company is filed under — but a company
+						// that contradicts on what it IS does not answer to it. Two
+						// unrelated firms reduce to one address more often than it
+						// sounds: the fold drops accents and cuts a long name short, so
+						// a Talleres Garcia in Girona and another in Sevilla are one
+						// address. Taking that as proof would file this company's people
+						// under somebody else while saying "already here".
+						const sharingAddress =
+							byNumber.length > 0
+								? []
+								: yield* sql`
+										SELECT * FROM companies
+										WHERE organization_id = ${currentOrg.id}
+											AND deleted_at IS NULL
+											AND slug = ${slug}
+										LIMIT 1
+									`
+
+						// Compared here rather than in the query, so a place is folded the
+						// same way names are folded everywhere else.
+						const disagreesOn = (held: unknown, offered: unknown): boolean => {
+							// Silence is not a disagreement, and neither is a shorter way
+							// of saying the same place: "Girona" inside "Girona, Catalunya"
+							// is one place, not two.
+							if (typeof held !== 'string' || held.trim() === '') return false
+							if (typeof offered !== 'string' || offered.trim() === '')
+								return false
+							const foldedHeld = foldLabel(held)
+							const foldedOffered = foldLabel(offered)
+							return (
+								foldedHeld !== '' &&
+								foldedOffered !== '' &&
+								!foldedHeld.includes(foldedOffered) &&
+								!foldedOffered.includes(foldedHeld)
 							)
 						}
-						return yield* Schema.decodeUnknownEffect(Schema.Array(Company))(
-							rows,
+
+						const holder = sharingAddress[0]
+						const heldByAnotherFirm =
+							holder !== undefined &&
+							(disagreesOn(holder['location'], args.company['location']) ||
+								(taxId !== '' &&
+									typeof holder['taxId'] === 'string' &&
+									normalizeTaxId(holder['taxId']) !== taxId))
+						const byAddress = heldByAnotherFirm ? [] : sharingAddress
+						const onFile = byNumber.length > 0 ? byNumber : byAddress
+
+						let row = onFile[0]
+						let created = false
+						if (row === undefined) {
+							const split = splitCompanyChannelFields(args.company)
+							const columns = withIndustry(
+								split.columns,
+								yield* industryForWrite(
+									sql,
+									currentOrg.id,
+									split.columns['industry'],
+								),
+							)
+
+							// A different firm already answers to this address, so this one
+							// takes an address of its own rather than being folded into it.
+							// Only ever reached on a real clash, which is why the address
+							// is the plain one the rest of the time.
+							//
+							// Told apart by whatever made it a different firm — its place,
+							// or failing that its number. Both stay the same from one
+							// offer to the next, so this company answers to one address
+							// ever after; something picked at random would hand it a new
+							// one every time and file it again on every click.
+							const toldApartBy =
+								foldLabel(
+									typeof args.company['location'] === 'string'
+										? args.company['location']
+										: '',
+								).replace(/\s+/g, '-') || taxId.toLowerCase()
+							const filedUnder =
+								heldByAnotherFirm && toldApartBy !== ''
+									? `${slug}-${toldApartBy}`.slice(0, 60)
+									: slug
+
+							// Nothing was here a moment ago, so a conflict now means
+							// another request filed the same company in between. That is
+							// the same answer as finding it in the first place — it is
+							// here — and saying so beats failing the click on a race the
+							// person cannot see or do anything about.
+							const inserted = yield* sql`
+								INSERT INTO companies ${sql.insert({ ...columns, slug: filedUnder, organizationId: currentOrg.id })}
+								ON CONFLICT (organization_id, slug) WHERE deleted_at IS NULL
+								DO NOTHING
+								RETURNING *
+							`
+							row = inserted[0]
+							created = row !== undefined
+
+							if (row === undefined) {
+								// Another request filed it between the look and the write.
+								const raced = yield* sql`
+									SELECT * FROM companies
+									WHERE organization_id = ${currentOrg.id}
+										AND deleted_at IS NULL
+										AND slug = ${filedUnder}
+									LIMIT 1
+								`
+								row = raced[0]
+							}
+
+							if (row !== undefined && created && split.channels.length > 0) {
+								yield* writeChannels(
+									sql,
+									currentOrg.id,
+									{ table: 'companies', id: String(row['id']) },
+									split.channels,
+								)
+							}
+						}
+
+						if (row === undefined)
+							return yield* Effect.die(
+								new Error('company insert returned no row'),
+							)
+
+						const companyId = String(row['id'])
+
+						// A company already here, now offered with the number it is
+						// registered under, and nothing on file. Written down, because it
+						// is what recognises this firm the next time it arrives under a
+						// name that gives a different address — which is the duplicate
+						// this whole step exists to stop.
+						if (
+							!created &&
+							taxId !== '' &&
+							(row['taxId'] === null || row['taxId'] === undefined)
+						) {
+							yield* sql`
+								UPDATE companies
+								SET tax_id = ${String(args.company['taxId'])}, updated_at = now()
+								WHERE id = ${companyId} AND organization_id = ${currentOrg.id}
+							`
+						}
+
+						const held = yield* sql`
+							SELECT name FROM contacts
+							WHERE organization_id = ${currentOrg.id}
+								AND company_id = ${companyId}
+								AND deleted_at IS NULL
+						`
+						// Folded before comparing, so the same person written with an
+						// accent one time and without it the next is one person.
+						const heldNames = new Set(
+							held.map(person => foldLabel(String(person['name']))),
 						)
+
+						let contactsAdded = 0
+						for (const person of args.contacts) {
+							const key = foldLabel(person.name)
+							if (key === '' || heldNames.has(key)) continue
+							heldNames.add(key)
+							yield* sql`INSERT INTO contacts ${sql.insert({
+								organizationId: currentOrg.id,
+								companyId,
+								name: person.name,
+								role: person.role ?? null,
+							})}`
+							contactsAdded++
+						}
+
+						return {
+							company: yield* Schema.decodeUnknownEffect(Company)(row),
+							created,
+							contactsAdded,
+						}
 					}),
 
 				// Take a company out of view without losing it. Its people go with

--- a/apps/server/src/services/company-geocoding.test.ts
+++ b/apps/server/src/services/company-geocoding.test.ts
@@ -35,8 +35,8 @@ const companyServiceWith = (
 		softDelete: () => Effect.die(unused),
 		restore: () => Effect.die(unused),
 		findBySlug: () => Effect.die(unused),
-		create: () => Effect.die(unused),
 		createMany: () => Effect.die(unused),
+		createWithContacts: () => Effect.die(unused),
 		getWithRelations: () => Effect.die(unused),
 	})
 

--- a/apps/server/src/services/research-apply.ts
+++ b/apps/server/src/services/research-apply.ts
@@ -11,6 +11,7 @@ import {
 	CompanyTag,
 	channelAddressIsValid,
 	isVerificationVerdict,
+	jobTitleOrNothing,
 	MAPS_ADDRESS_PATTERN,
 } from '@batuda/domain'
 import {
@@ -222,7 +223,8 @@ const resolveFieldSources = (
 /**
  * Keep only the proposal fields that map to a writable column on the target
  * table, normalizing snake_case keys to the camelCase the SQL client expects,
- * and collect the page each kept value was cited to.
+ * settling a blank job title as no job title, and collecting the page each kept
+ * value was cited to.
  */
 export const allowlistFields = (
 	table: 'companies' | 'contacts',
@@ -238,7 +240,13 @@ export const allowlistFields = (
 		const camel = snakeToCamel(key)
 		if (!allowed.has(camel)) continue
 		const read = readSourced(value)
-		out[camel] = read.value
+		// A job title read as blank is one nobody gave. Settled here rather than at
+		// the write, because a proposal reaches the row through two statements — an
+		// insert for a person the run found and an update for one already on file.
+		out[camel] =
+			camel === 'role' && typeof read.value === 'string'
+				? jobTitleOrNothing(read.value)
+				: read.value
 		if (read.citation !== undefined) citations[camel] = read.citation
 	}
 	return { fields: out, citations }

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -946,6 +946,7 @@ const fireWebhooks = (event: string, payload: unknown) =>
 Events fired:
 
 - `company.created`
+- `company.already_on_file` (a company offered a second time is answered with the one already here, so `company.created` does not fire for it)
 - `company.status_changed` (include `from` and `to` in payload)
 - `interaction.logged`
 - `email.sent`

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -48,44 +48,45 @@ The mail worker has no request and no scope at all, so `email.received` names th
 
 `{domain}.{action}[.{result}]` — so a filter on one prefix gets a whole area.
 
-| Event                          | Description                                                |
-| ------------------------------ | ---------------------------------------------------------- |
-| `http.request`                 | A request completed                                        |
-| `http.server_error`            | A request ended 5xx                                        |
-| `http.defect`                  | A request died without producing a response                |
-| `http.not_found`               | A request asked for a route that does not exist            |
-| `company.created`              | New company added to CRM                                   |
-| `company.status_changed`       | Pipeline status transition                                 |
-| `interaction.logged`           | Interaction recorded                                       |
-| `document.created`             | Research/notes document added                              |
-| `email.sent`                   | Outbound email starting a conversation                     |
-| `email.replied`                | Outbound email answering one                               |
-| `email.draft_sent`             | A saved draft went out                                     |
-| `email.received`               | Inbound reply                                              |
-| `email.failed`                 | Email delivery failed                                      |
-| `email.refused`                | A message was turned away before it was sent, and why      |
-| `email.sent_copy_failed`       | The message went out; keeping our own copy did not         |
-| `email.sent_append_failed`     | The message went out; filing it in Sent did not            |
-| `email.staging_purge_failed`   | Attachments outlived the message they went with            |
-| `inbox.created`                | A mailbox was connected                                    |
-| `inbox.probed`                 | A mailbox check that did not pass (a clean one is `debug`) |
-| `inbox.probe_unrecorded`       | A mailbox was checked but the answer could not be stored   |
-| `inbox.probe_started`          | The recurring mailbox check began, and how often it runs   |
-| `inbox.probe_round_failed`     | A whole round of checks failed — the poller, not a mailbox |
-| `mail_worker.heartbeat`        | The mail worker is still running, repeated on a timer      |
-| `webhook.fired`                | Webhook fan-out triggered                                  |
-| `webhook.failed`               | Webhook delivery failed                                    |
-| `page.published`               | Sales page made public                                     |
-| `page.viewed`                  | Prospect viewed a sales page                               |
-| `task.created`                 | CRM task raised                                            |
-| `research.run`                 | A research run finished, with what it spent                |
-| `mcp.auth.rejected`            | An MCP call was refused, and why                           |
-| `mcp.protocol_version.refused` | A call named a protocol revision this server does not know |
-| `otlp.export.failing`          | This process has stopped being able to export, and why     |
-| `otlp.export.recovered`        | Exporting works again                                      |
-| `otlp.export.health`           | Whether this process is exporting, repeated on a timer     |
-| `otlp.clock.skewed`            | This process and the backend disagree about the time       |
-| `otlp.clock.agreed`            | This process and the backend agree again                   |
+| Event                          | Description                                                 |
+| ------------------------------ | ----------------------------------------------------------- |
+| `http.request`                 | A request completed                                         |
+| `http.server_error`            | A request ended 5xx                                         |
+| `http.defect`                  | A request died without producing a response                 |
+| `http.not_found`               | A request asked for a route that does not exist             |
+| `company.created`              | New company added to CRM                                    |
+| `company.already_on_file`      | A company offered again, answered with the one already here |
+| `company.status_changed`       | Pipeline status transition                                  |
+| `interaction.logged`           | Interaction recorded                                        |
+| `document.created`             | Research/notes document added                               |
+| `email.sent`                   | Outbound email starting a conversation                      |
+| `email.replied`                | Outbound email answering one                                |
+| `email.draft_sent`             | A saved draft went out                                      |
+| `email.received`               | Inbound reply                                               |
+| `email.failed`                 | Email delivery failed                                       |
+| `email.refused`                | A message was turned away before it was sent, and why       |
+| `email.sent_copy_failed`       | The message went out; keeping our own copy did not          |
+| `email.sent_append_failed`     | The message went out; filing it in Sent did not             |
+| `email.staging_purge_failed`   | Attachments outlived the message they went with             |
+| `inbox.created`                | A mailbox was connected                                     |
+| `inbox.probed`                 | A mailbox check that did not pass (a clean one is `debug`)  |
+| `inbox.probe_unrecorded`       | A mailbox was checked but the answer could not be stored    |
+| `inbox.probe_started`          | The recurring mailbox check began, and how often it runs    |
+| `inbox.probe_round_failed`     | A whole round of checks failed — the poller, not a mailbox  |
+| `mail_worker.heartbeat`        | The mail worker is still running, repeated on a timer       |
+| `webhook.fired`                | Webhook fan-out triggered                                   |
+| `webhook.failed`               | Webhook delivery failed                                     |
+| `page.published`               | Sales page made public                                      |
+| `page.viewed`                  | Prospect viewed a sales page                                |
+| `task.created`                 | CRM task raised                                             |
+| `research.run`                 | A research run finished, with what it spent                 |
+| `mcp.auth.rejected`            | An MCP call was refused, and why                            |
+| `mcp.protocol_version.refused` | A call named a protocol revision this server does not know  |
+| `otlp.export.failing`          | This process has stopped being able to export, and why      |
+| `otlp.export.recovered`        | Exporting works again                                       |
+| `otlp.export.health`           | Whether this process is exporting, repeated on a timer      |
+| `otlp.clock.skewed`            | This process and the backend disagree about the time        |
+| `otlp.clock.agreed`            | This process and the backend agree again                    |
 
 The `otlp.*` lines are the exception to one record per unit of work: they report on the reporting itself, so they belong to the process rather than to any piece of work it did. See [When export itself fails](#when-export-itself-fails).
 

--- a/packages/controllers/src/routes/companies.ts
+++ b/packages/controllers/src/routes/companies.ts
@@ -78,6 +78,11 @@ const CompanySuppressionCleared = Schema.Struct({
 	channels: Schema.Array(Schema.Unknown),
 })
 
+const LeadContactInput = Schema.Struct({
+	name: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
+	role: Schema.optional(Schema.String),
+})
+
 // What a caller may write. The shapes come from the domain so the browser and
 // the agent tools turn away the same values — and they sit here rather than on
 // `Company`, which has to keep reading rows written before any of this existed.
@@ -117,6 +122,34 @@ export const CreateCompanyInput = Schema.Struct({
 	geocodedAt: Schema.optional(Schema.DateTimeUtc),
 	geocodeSource: Schema.optional(Schema.String),
 	metadata: Schema.optional(Schema.Unknown),
+	// The number the company is registered or taxed under. Carried because it is
+	// the only thing that recognises the same firm arriving under a different
+	// trading name — the name and the web address both change, the registration
+	// does not.
+	taxId: Schema.optional(Schema.String),
+	// The people a company search read off the company's own pages, taken on with
+	// it so a list of firms arrives with somebody to ask for. A job title only: a
+	// search has no way of knowing who holds the budget, so the part a person
+	// plays in a purchase is left unsaid rather than guessed.
+	contacts: Schema.optional(Schema.Array(LeadContactInput)),
+})
+
+/**
+ * What comes back from taking a company on.
+ *
+ * More than the company row, because two things the caller cannot work out for
+ * itself decide what it says next: whether this call put the company on file or
+ * found one already there, and how many of the people it sent were new. Sending
+ * the same prospect twice is a normal thing to do — a person scrolling a list of
+ * fifty loses their place — and it should land on the company, not make a second
+ * one.
+ */
+export const CreateCompanyResult = Schema.Struct({
+	company: Company.json,
+	/** False when the company was already on file and this call found it. */
+	created: Schema.Boolean,
+	/** People written. Anyone the company already had is not counted again. */
+	contactsAdded: Schema.Number,
 })
 
 // Every field a person can empty from the company page is nullable here. The page
@@ -285,7 +318,7 @@ export const CompaniesGroup = HttpApiGroup.make('companies')
 	.add(
 		HttpApiEndpoint.post('create', '/companies', {
 			payload: CreateCompanyInput,
-			success: Company.json,
+			success: CreateCompanyResult,
 		}),
 	)
 	.add(

--- a/packages/controllers/src/routes/companies.ts
+++ b/packages/controllers/src/routes/companies.ts
@@ -80,7 +80,7 @@ const CompanySuppressionCleared = Schema.Struct({
 
 const LeadContactInput = Schema.Struct({
 	name: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
-	role: Schema.optional(Schema.String),
+	role: Schema.optional(Schema.NullOr(Schema.String)),
 })
 
 // What a caller may write. The shapes come from the domain so the browser and

--- a/packages/controllers/src/routes/contacts.ts
+++ b/packages/controllers/src/routes/contacts.ts
@@ -39,7 +39,9 @@ const CreateContactInput = Schema.Struct({
 	// The branch this person works at, when the company has more than one.
 	siteId: Schema.optional(Schema.String),
 	name: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
-	role: Schema.optional(Schema.String),
+	// Null is taken because a caller has to be able to say a person has no job
+	// title — on an update it is the only way to take one back off.
+	role: Schema.optional(Schema.NullOr(Schema.String)),
 	// Null is one of the answers, not a value gone missing: "nobody has said what
 	// part this person plays in a purchase" is the usual state, so a caller saying
 	// so outright is taken rather than turned away — and on an update it is the
@@ -52,7 +54,7 @@ const CreateContactInput = Schema.Struct({
 const UpdateContactInput = Schema.Struct({
 	siteId: Schema.optional(Schema.NullOr(Schema.String)),
 	name: Schema.optional(Schema.String),
-	role: Schema.optional(Schema.String),
+	role: Schema.optional(Schema.NullOr(Schema.String)),
 	buyingRole: Schema.optional(Schema.NullOr(Schema.String)),
 	metadata: Schema.optional(Schema.Unknown),
 	channels: Schema.optional(Schema.Array(ChannelInput)),

--- a/packages/controllers/src/routes/contacts.ts
+++ b/packages/controllers/src/routes/contacts.ts
@@ -40,7 +40,11 @@ const CreateContactInput = Schema.Struct({
 	siteId: Schema.optional(Schema.String),
 	name: Schema.String.pipe(Schema.check(Schema.isMinLength(1))),
 	role: Schema.optional(Schema.String),
-	buyingRole: Schema.optional(Schema.String),
+	// Null is one of the answers, not a value gone missing: "nobody has said what
+	// part this person plays in a purchase" is the usual state, so a caller saying
+	// so outright is taken rather than turned away — and on an update it is the
+	// only way to take a part back off once it has been named.
+	buyingRole: Schema.optional(Schema.NullOr(Schema.String)),
 	metadata: Schema.optional(Schema.Unknown),
 	channels: Schema.optional(Schema.Array(ChannelInput)),
 })
@@ -49,7 +53,7 @@ const UpdateContactInput = Schema.Struct({
 	siteId: Schema.optional(Schema.NullOr(Schema.String)),
 	name: Schema.optional(Schema.String),
 	role: Schema.optional(Schema.String),
-	buyingRole: Schema.optional(Schema.String),
+	buyingRole: Schema.optional(Schema.NullOr(Schema.String)),
 	metadata: Schema.optional(Schema.Unknown),
 	channels: Schema.optional(Schema.Array(ChannelInput)),
 })

--- a/packages/domain/src/schema/contacts.test.ts
+++ b/packages/domain/src/schema/contacts.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { jobTitleOrNothing } from './contacts'
+
+describe('jobTitleOrNothing', () => {
+	describe('when no title was given', () => {
+		it('should read the same however the caller said so', () => {
+			// GIVEN the three ways a caller says there is no job title — a form that
+			// cleared the box, a caller that left the field out, and one taking a
+			// wrong title back off
+			// THEN all three are one answer, so a reader has one absence to know
+			// about rather than three
+			expect(jobTitleOrNothing('')).toBeNull()
+			expect(jobTitleOrNothing(undefined)).toBeNull()
+			expect(jobTitleOrNothing(null)).toBeNull()
+		})
+
+		it('should read a title of nothing but spaces as no title', () => {
+			// GIVEN a box that looks filled in and says nothing
+			for (const written of [' ', '   ', '\t', '\n  ']) {
+				// THEN it is no title, not a title made of whitespace
+				expect(jobTitleOrNothing(written), JSON.stringify(written)).toBeNull()
+			}
+		})
+	})
+
+	describe('when a title was given', () => {
+		it('should keep it as the page wrote it', () => {
+			// GIVEN a title copied off a company's own page
+			// THEN it is kept as written — accents, punctuation, case and all. It gets
+			// quoted back confidently in an opening line, so a tidied one is a mistake
+			// somebody makes out loud
+			expect(jobTitleOrNothing('CEO - Enginyer Industrial')).toBe(
+				'CEO - Enginyer Industrial',
+			)
+			expect(jobTitleOrNothing("Cap d'obres")).toBe("Cap d'obres")
+		})
+
+		it('should take the surrounding spaces off', () => {
+			// GIVEN a title with the spacing a copy-paste leaves behind
+			// THEN the title survives and the spacing does not
+			expect(jobTitleOrNothing('  Directora Financera  ')).toBe(
+				'Directora Financera',
+			)
+		})
+
+		it('should keep a title that is only a number or a symbol', () => {
+			// GIVEN titles that are not words
+			// THEN both are kept. Whether they are useful is the caller's business;
+			// this only decides whether something was said at all
+			expect(jobTitleOrNothing('2')).toBe('2')
+			expect(jobTitleOrNothing('-')).toBe('-')
+		})
+	})
+})

--- a/packages/domain/src/schema/contacts.ts
+++ b/packages/domain/src/schema/contacts.ts
@@ -49,3 +49,18 @@ export class Contact extends Model.Class<Contact>('Contact')({
 	createdAt: Model.DateTimeInsertFromDate,
 	updatedAt: Model.DateTimeUpdateFromDate,
 }) {}
+
+/**
+ * The job title a person was given, or nothing — never blank.
+ *
+ * A form whose box was cleared sends an empty string, a caller with nothing to
+ * put there leaves the field out, and both mean the same thing. Kept as two
+ * different values they stop being one thing: a reader then has to know a title
+ * can be absent in two ways, one of which answers yes to "is there a title".
+ */
+export const jobTitleOrNothing = (
+	role: string | null | undefined,
+): string | null => {
+	const given = role?.trim() ?? ''
+	return given === '' ? null : given
+}

--- a/packages/domain/src/schema/index.ts
+++ b/packages/domain/src/schema/index.ts
@@ -67,7 +67,7 @@ export {
 	ContactChannelId,
 	EmailStatus,
 } from './contact-channels'
-export { Contact, ContactId } from './contacts'
+export { Contact, ContactId, jobTitleOrNothing } from './contacts'
 export {
 	DOCUMENT_FORMATS,
 	DOCUMENT_TYPES,


### PR DESCRIPTION
## What

A company search already brings back the people each company names on its own pages. Until now, clicking **Add as lead** threw them away — the company landed in the CRM and the names stayed on the research screen, to be retyped by hand. This carries them across, along with the number the company is registered under, and does the same for an assistant working through the agent tools.

It also stops the button making a second copy of a company you already have. Every click used to write a brand-new row, because the web address each lead was filed under carried five random characters — so no two clicks could ever be recognised as the same firm.

Along the way it settles a smaller thing that had been getting a person's job title written down two different ways.

This sits in the CRM, across four surfaces: the typed contract both the browser and the server read (`packages/controllers`), the company service in `server`, the research findings screen in the internal app, and the agent tools (MCP).

## Changes

**Touches:** what the browser and the agent tools may send when they create a company, the service that writes the row, the research findings screen that sends it, and — separately — the form for adding a person by hand.

- A prospect's people travel with it and become contacts on the company. What part they play in a purchase is deliberately left unsaid: a search reads a job title off a page and has no way of knowing who holds the budget, so that stays for a person to fill in.
- The registration number travels too. It is the one thing that recognises the same firm when it arrives later under a trading name that gives a different web address — the name changes, the address changes, the registration does not.
- Clicking the same prospect twice now lands on the company already there and says so, instead of filing a second one.
- Two genuinely different firms that reduce to the same web address are kept apart, by the town they are in or by their registration numbers. Folding them together would write one firm's people onto the other's record while reporting success, which is worse than the duplicate it replaced because nobody would see it.
- **The agent tools do the same.** `create_companies` takes a company's people alongside it, so an assistant loading a shortlist of fifty makes one call rather than one per person. People land where the same firm is established — this call created it, or its registration number matched. Where only the web address matched, nothing is written and the tool says so: an address is folded from the name, so two unrelated firms reduce to one often enough that writing there would file one firm's people under another.
- **A company the agent tools leave out now comes back with the call.** It used to answer with a web address and nothing else, and on a registration-number match that address is the one the caller sent, not the one the company is filed under — so there was nothing to go and look up.
- Separately: adding a person by hand failed whenever the part they play in a purchase was left at its default — which is nearly always. The form sends "nobody has said" as null and the contract refused it.
- Separately again: **a job title nobody gave is now written down one way.** The form left the field out when adding somebody and sent it blank when editing them, so the column held two spellings of the same silence — and a blank one answers yes to "is there a title". Every door that writes one settles it now, and an assistant can take a title off at all, which it had no way to say before.

## Impact

- **What creating a company answers with has changed**, from the company row alone to the row plus whether it was created or found and how many people were new. There is exactly one caller — the Add-as-lead button — and both workspaces that read the contract type-check against it, so a second caller could not have gone unnoticed. Nothing outside this repo reads it; the package is private.
- **What `create_companies` answers with has changed too.** It gains a count of the people written, and each left-out company now carries the company that matched — five fields, not the whole record, because a re-sent list of fifty would otherwise come back as fifty full account briefs and their per-field provenance.
- **A repeat click no longer fires the `company.created` event.** It fires `company.already_on_file` instead, which is now listed in the observability notes and in the backend guide — otherwise a counter built on the first one would show an unexplained drop.
- **Nothing to run before deploying.** No database migration: `tax_id` and the contacts table already existed, and the job-title column is unchanged. No blank job titles exist in any development database to back-fill; production was not checked from here, and `UPDATE contacts SET role = NULL WHERE role = ''` is a safe no-op if you want certainty.
- **Nothing touching which organisation can see what (row-level security)**, no new environment variables, and no change to who can reach which route. The company and its people are written inside the transaction each request already runs in, so a lead never half-lands, and the agent tools' batch stays one transaction.

## Review guide

- **Start at `createWithContacts` in `apps/server/src/services/companies.ts`.** It resolves a company in three stages — registration number, then web address unless the company holding it contradicts, then insert — and that ordering is the whole safety argument. The thing to disagree with is using the *town* to tell two same-named firms apart: it is a free-text field, so two spellings of one place will produce a duplicate. I chose that over the alternative, which writes one firm's people onto another firm's record silently.
- The address a clashing firm falls back to is derived from its town or its number, never random, so it is recognised on the next click. An earlier draft used a random suffix there and would have filed a new company on every click — the bug this change exists to remove.
- **Then `createMany` in the same file**, which the agent tools use. It asks the registration number before the web address, and that order is load-bearing rather than cosmetic: asking the address first calls one firm sent twice a repeat and drops the second entry's people on the strength of a folded name. Each branch says what it does with the offered people.
- **`CREATE_COMPANIES_DESCRIPTION` deserves reading as code.** It is the only documentation an assistant gets, and two rounds of review found it stating things the code does not do. Worth checking sentence by sentence against the branches.
- **Skip-able:** the two `.po` catalogue files are generated by `i18n:extract`.

## Screenshots

The EGEIN company page after one click of **Add as lead**, with the two people the search read off the company's own team page — and `Rosa López`, added by hand afterwards with the buying role left at its default, which is the path that used to fail.

**Desktop (1440×900)**

![pr-lead-people-desktop](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-642/pr-lead-people.webp)

**Mobile (iPhone 16 Pro)** — both captured because this screen is mobile-first.

![pr-lead-people-mobile](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-642/pr-lead-people-mobile.webp)

Clicking the same prospect a second time, showing it lands on the company already on file rather than making another:

![pr-lead-already-on-file](https://pub-4a0e93639af04c8f80208b4ba7453566.r2.dev/batuda/pr-642/pr-lead-already.webp)

## Tests

Twenty-four integration cases against the live database, covering what a type check cannot see. On the lead button: a second click landing on the company already there, a person already on file not being written twice, `Mercè Solà` and `Merce Sola` recognised as one person, the same firm under a different trading name caught by its number, two firms in different towns kept apart and each recognised again afterwards, and a registration number offered later being kept rather than dropped. On the agent tools: people landing on a company that was created and on one matched by its number, one firm sent twice in a call keeping both entries' people, and a same-named firm elsewhere getting nobody written onto it. On the job title: created blank, cleared to blank, taken off with null, and an unrelated edit leaving it alone. Plus unit coverage on what the browser sends and on the rule itself.

## Verification

- Gates run: `pnpm install`, `pnpm exec turbo check-types`, `pnpm exec turbo test`, `pnpm -w build` — all green. The `apps/server` integration suite (937 tests, up from 923) run separately, green; the plain `test` task excludes it.
- Driven end to end against the local stack, not just tested. **Add as lead**: clicked it, confirmed in the database that the company landed with `tax_id` set and both people with their job titles and no buying role; clicked again and confirmed one company, one address, two people, with an "Already on file" message; then added a third person by hand without touching the buying role and confirmed it saved. **Job title**: cleared the title on a contact who has a buying role set — the combination that used to fail outright — and confirmed the column holds null rather than a blank, with the buying role untouched; added a contact with no title and confirmed the same. No blank titles anywhere in the database afterwards.
- Reviewed by five independent passes in total, with fixes re-reviewed. They found sixteen issues worth acting on. The sharpest: a first fix of mine refused `undefined` where the old code refused `null`, the exact mirror of the bug; and the agent-tools batch asked the web address before the registration number, so one firm sent twice under the same name lost its second entry's people — the policy defeated by statement order. Two reported issues were false positives, checked and dismissed — one of them a race I disproved by reproducing it against two live Postgres sessions rather than reasoning about it.

## Deferred

- A job title found for somebody already on file is dropped rather than filling an empty one. The person is recognised and left alone, which is right for a name and arguably wrong for a title a search has just found.
- The agent tools still will not file a genuinely different same-named firm under a web address of its own, the way the lead button does — they report it and leave it to the caller.
