### PR TITLE
cicd: source the MinIO images from quay rather than docker hub

### DIFF
--- a/.claude/hooks/worktree-down.sh
+++ b/.claude/hooks/worktree-down.sh
@@ -70,7 +70,7 @@ docker exec batuda-db psql -U batuda -d postgres \
 # ${db#batuda_} is <slug> and this can never target the main checkout's batuda_it.
 docker exec batuda-db psql -U batuda -d postgres \
 	-c "DROP DATABASE IF EXISTS batuda_it__${db#batuda_} WITH (FORCE)" >/dev/null 2>&1 || true
-docker run --rm --network batuda_default --entrypoint /bin/sh minio/mc:latest \
+docker run --rm --network batuda_default --entrypoint /bin/sh quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z \
 	-c "mc alias set local http://storage:9000 batuda batuda-secret >/dev/null 2>&1 && mc rb --force local/${bucket}" \
 	>/dev/null 2>&1 || true
 exit 0

--- a/apps/cli/src/commands/worktree.ts
+++ b/apps/cli/src/commands/worktree.ts
@@ -414,11 +414,16 @@ const dropDatabase = (db: string) =>
 		),
 	)
 
-// The minio/mc image's entrypoint is `mc` itself, so override it with a shell
-// (as the storage-init sidecar does) to set the alias then run one command,
-// reaching the shared MinIO over the compose network.
+// The same image and release the storage-init sidecar uses, from the registry
+// MinIO publishes to — kept in step with docker/docker-compose.yml so a worktree
+// and the shared stack never speak to MinIO through two different clients.
+const MC_IMAGE = 'quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z'
+
+// The mc image's entrypoint is `mc` itself, so override it with a shell (as the
+// storage-init sidecar does) to set the alias then run one command, reaching the
+// shared MinIO over the compose network.
 const mcScript = (command: string) =>
-	`docker run --rm --network ${STORAGE_NETWORK} --entrypoint /bin/sh minio/mc:latest -c "mc alias set local http://storage:9000 batuda batuda-secret >/dev/null 2>&1 && ${command}"`
+	`docker run --rm --network ${STORAGE_NETWORK} --entrypoint /bin/sh ${MC_IMAGE} -c "mc alias set local http://storage:9000 batuda batuda-secret >/dev/null 2>&1 && ${command}"`
 
 const mc = (command: string) => dockerFail(exec(mcScript(command)))
 const mcCapture = (command: string) => execSilent(mcScript(command))

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,10 +43,13 @@ services:
   storage:
     container_name: batuda-storage
     # Pinned like every other service here: `latest` re-checks the registry on
-    # every start, so a slow day at Docker Hub failed the build rather than
+    # every start, so a slow day at the registry failed the build rather than
     # reusing what was already on the machine — and it could change underneath
     # a laptop between two mornings.
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    #
+    # Taken from quay.io, which is where MinIO publishes these: the same
+    # releases under docker.io cannot be pulled, by CI or by anyone.
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     command: server /data --console-address ":9001"
     ports:
       - "9000:9000" # S3 API
@@ -61,7 +64,7 @@ services:
   # safe to re-run; exits 0 once the bucket exists.
   storage-init:
     container_name: batuda-storage-init
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       - storage
     restart: "no"


### PR DESCRIPTION
## What

Continuous integration cannot start its database and object storage, so every pull request fails and nothing can merge. The two MinIO images the local stack is built on — the storage server and its command-line client — can no longer be pulled from Docker Hub:

```
pull access denied for minio/minio, repository does not exist or may require 'docker login'
```

This is not rate limiting dressed up as a denial: Docker Hub still issues an anonymous pull token, and the same pull fails from a developer laptop as well as from a runner. MinIO publishes the same releases to quay.io, so this takes them from there.

## Changes

**Touches:** the shared Docker stack, and the two places the worktree commands reach for the MinIO client on their own.

- `docker/docker-compose.yml` names `quay.io/minio/minio` and `quay.io/minio/mc`, at the releases it already pinned. No version moves.
- The worktree commands (`pnpm cli worktree up` / `down`, and the session hook that tears a worktree down) fetched their own copy of the client and left it on `latest`. They now name the same release the shared stack runs, from the same registry — an unpinned client drifting from the server it talks to is the thing the compose file's own pinning comment warns about.

## Impact

- **Nothing about storage behaves differently.** The quay images are byte-identical to the Docker Hub ones: the same tags resolve to the same image ids (`8f08aee61480` for the server, `5dee113ef037` for the client), confirmed against copies still cached locally from before.
- **Anyone with the old images cached keeps working either way** — this only decides where a machine that does not have them goes to look. That is every runner, every fresh clone, and any laptop that prunes.
- **No environment variables, no credentials, no migration.** quay.io serves these anonymously.
- This is not only a continuous-integration fix: on a machine without the images cached, `pnpm cli services up` and `pnpm cli worktree up` fail the same way today.

## Review guide

- The only judgement call is pinning the two worktree references that were on `latest`. That is a behaviour change beyond the registry swap — they will now use a fixed release rather than whatever `latest` resolves to on the day. I think it is right for the reason the compose file already gives, but it is the one thing here worth disagreeing with.
- Everything else is a one-word prefix on an image name.

## Verification

- Ran the exact command continuous integration runs and that is failing on `main` right now — `docker compose -f docker/docker-compose.yml pull --quiet db storage storage-init` — against this branch: exits 0, all three images pulled.
- Ran the worktree commands' own client line from the quay image against the live stack: it set its alias and listed the real buckets.
- Compared image ids against the Docker Hub copies still cached locally; identical for both images.
- `pnpm exec turbo check-types` 14/14, Biome and dprint clean, `docker compose config` validates, and the teardown hook parses under `bash -n`.
- The `apps/server` integration suite run against this branch: 912 tests, green.
