### PR TITLE
fix: name every mail failure and say whose mailbox it was

### DIFF
--- a/apps/mail-worker/src/inbox-session.test.ts
+++ b/apps/mail-worker/src/inbox-session.test.ts
@@ -1,8 +1,14 @@
 import { EventEmitter } from 'node:events'
 
+import { Cause, Effect, Layer, Logger, References } from 'effect'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { onImapClientError, resolveTrackedFolders } from './inbox-session.js'
+import {
+	folderReadFailed,
+	idleWaitFailed,
+	onImapClientError,
+	resolveTrackedFolders,
+} from './inbox-session.js'
 
 // Spy on console.warn so the handler's single JSON line is captured, not printed.
 const captureWarn = () =>
@@ -210,6 +216,126 @@ describe('resolveTrackedFolders', () => {
 			expect(resolveTrackedFolders(boxes)).toEqual([
 				{ path: 'INBOX', direction: 'inbound' },
 			])
+		})
+	})
+})
+
+// Reads back every line an effect writes. Annotations sit on the fiber rather
+// than on the log options, so they are read the way the built-in formatters
+// read them.
+const captureLines = () => {
+	const lines: Array<{
+		level: string
+		message: string
+		annotations: Record<string, unknown>
+	}> = []
+	const layer = Logger.layer([
+		Logger.make(options => {
+			lines.push({
+				level: String(options.logLevel),
+				message: String(options.message),
+				annotations: options.fiber.getRef(
+					References.CurrentLogAnnotations,
+				) as Record<string, unknown>,
+			})
+		}),
+	]).pipe(
+		Layer.provideMerge(Layer.succeed(References.MinimumLogLevel, 'Debug')),
+	)
+	return { lines, layer }
+}
+
+const readLines = async (effect: Effect.Effect<void>) => {
+	const { lines, layer } = captureLines()
+	await Effect.runPromise(effect.pipe(Effect.provide(layer)))
+	return lines
+}
+
+const inbox = { id: 'inbox-1', organizationId: 'org-1' } as const
+
+describe('the lines a sync pass leaves when the mail server will not cooperate', () => {
+	describe('when a folder cannot be read', () => {
+		it('should name the event and say which tenant and folder it was about', async () => {
+			// GIVEN a folder read that failed
+			// WHEN the failure is written down
+			const lines = await readLines(
+				folderReadFailed({
+					inbox,
+					folder: 'INBOX',
+					cause: Cause.fail(new Error('Connection not available')),
+				}),
+			)
+
+			// THEN every line it writes should carry the name and the tenant
+			expect(lines.length).toBeGreaterThan(0)
+			for (const line of lines) {
+				expect(line.annotations['event']).toBe('email.folder_read_failed')
+				expect(line.annotations['org.id']).toBe('org-1')
+				expect(line.annotations['inboxId']).toBe('inbox-1')
+				expect(line.annotations['folder']).toBe('INBOX')
+			}
+		})
+
+		it('should keep the reason out of the message and in a bounded cause', async () => {
+			// GIVEN a failure whose cause names the underlying problem
+			// WHEN the failure is written down
+			const lines = await readLines(
+				folderReadFailed({
+					inbox,
+					folder: 'Sent',
+					cause: Cause.fail(new Error('Connection not available')),
+				}),
+			)
+
+			// THEN one line should read as a sentence and another carry the cause
+			expect(lines[0]?.message).toBe('Reading a folder failed')
+			expect(
+				lines.some(line => line.message.includes('Connection not available')),
+			).toBe(true)
+		})
+	})
+
+	describe('when waiting for the mail server to report a change fails', () => {
+		it('should get a name of its own rather than a bare stack', async () => {
+			// GIVEN the wait failed
+			// WHEN the failure is written down
+			const lines = await readLines(
+				idleWaitFailed({
+					inbox,
+					folder: 'INBOX',
+					cause: Cause.fail(new Error('Connection not available')),
+				}),
+			)
+
+			// THEN it should be filterable by name, tenant and folder
+			expect(lines.length).toBeGreaterThan(0)
+			for (const line of lines) {
+				expect(line.annotations['event']).toBe('email.idle_wait_failed')
+				expect(line.annotations['org.id']).toBe('org-1')
+				expect(line.annotations['inboxId']).toBe('inbox-1')
+				expect(line.annotations['folder']).toBe('INBOX')
+			}
+			expect(lines[0]?.message).toBe('Waiting for mailbox changes failed')
+		})
+
+		it('should not be mistaken for a folder read failure', async () => {
+			// GIVEN both failures happen in the same pass
+			// WHEN each is written down
+			const waitLines = await readLines(
+				idleWaitFailed({
+					inbox,
+					folder: 'INBOX',
+					cause: Cause.fail(new Error('boom')),
+				}),
+			)
+
+			// THEN the wait failure should not answer to the folder-read name,
+			// so a count of one is not silently the other
+			expect(
+				waitLines.every(
+					line => line.annotations['event'] !== 'email.folder_read_failed',
+				),
+			).toBe(true)
 		})
 	})
 })

--- a/apps/mail-worker/src/inbox-session.ts
+++ b/apps/mail-worker/src/inbox-session.ts
@@ -1,4 +1,4 @@
-import { Effect, Result, Schedule } from 'effect'
+import { type Cause, Effect, Result, Schedule } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 import { ImapFlow } from 'imapflow'
 
@@ -32,6 +32,45 @@ export const onImapClientError =
 			}),
 		)
 	}
+
+// What the two failures of a sync pass leave in the logs. Both name the
+// tenant: this worker serves every mailbox we hold and has no request to
+// take one from, so a line that skips it cannot be traced to a customer.
+// Exported for the same reason as `onImapClientError` — so a test can read
+// back what somebody filtering these lines has to work with.
+export const folderReadFailed = (args: {
+	readonly inbox: Pick<ClaimedInbox, 'id' | 'organizationId'>
+	readonly folder: string
+	readonly cause: Cause.Cause<unknown>
+}) =>
+	Effect.logWarning('Reading a folder failed').pipe(
+		Effect.andThen(Effect.logError(boundedCause(args.cause))),
+		Effect.annotateLogs({
+			event: 'email.folder_read_failed',
+			'org.id': args.inbox.organizationId,
+			inboxId: args.inbox.id,
+			folder: args.folder,
+		}),
+	)
+
+// A pass spends nearly all of its time waiting for the mail server to say
+// something changed, so a failure here is the difference between mail
+// arriving late and not arriving at all. It used to go down as a bare stack
+// with no name, which no query could group, count or alert on.
+export const idleWaitFailed = (args: {
+	readonly inbox: Pick<ClaimedInbox, 'id' | 'organizationId'>
+	readonly folder: string
+	readonly cause: Cause.Cause<unknown>
+}) =>
+	Effect.logWarning('Waiting for mailbox changes failed').pipe(
+		Effect.andThen(Effect.logError(boundedCause(args.cause))),
+		Effect.annotateLogs({
+			event: 'email.idle_wait_failed',
+			'org.id': args.inbox.organizationId,
+			inboxId: args.inbox.id,
+			folder: args.folder,
+		}),
+	)
 
 // Folders we monitor per inbox, and what finding a message in one means.
 // Gmail's "All Mail" duplicates everything (covered by IMAP \All
@@ -333,6 +372,10 @@ export const runInboxSession = (claimed: ClaimedInbox) =>
 
 		yield* Effect.gen(function* () {
 			while (true) {
+				// Whether anything in this pass failed to read. A mailbox whose
+				// folders would not open is not one we have just seen, so saying
+				// so would wipe the error that explains why no mail is arriving.
+				let readFailed = false
 				for (const folder of folders) {
 					yield* syncOneFolderTick({
 						client,
@@ -343,18 +386,21 @@ export const runInboxSession = (claimed: ClaimedInbox) =>
 						progress,
 					}).pipe(
 						Effect.catchCause(cause =>
-							Effect.logWarning('Reading a folder failed').pipe(
-								Effect.andThen(Effect.logError(boundedCause(cause))),
-								Effect.annotateLogs({
-									event: 'email.folder_read_failed',
-									inboxId: claimed.id,
-									folder: folder.path,
-								}),
+							folderReadFailed({
+								inbox: claimed,
+								folder: folder.path,
+								cause,
+							}).pipe(
+								Effect.andThen(
+									Effect.sync(() => {
+										readFailed = true
+									}),
+								),
 							),
 						),
 					)
 				}
-				yield* markHealthy(claimed.id)
+				if (!readFailed) yield* markHealthy(claimed.id)
 
 				// Hold IMAP IDLE so the server can push `exists`/`expunge` mid-IDLE.
 				// imapflow surfaces those as events rather than resolving idle(), so
@@ -370,7 +416,13 @@ export const runInboxSession = (claimed: ClaimedInbox) =>
 							`mailboxOpen(${folderToWaitOn.path}) failed: ${String(err)}`,
 						),
 				}).pipe(
-					Effect.catchCause(cause => Effect.logError(boundedCause(cause))),
+					Effect.catchCause(cause =>
+						idleWaitFailed({
+							inbox: claimed,
+							folder: folderToWaitOn.path,
+							cause,
+						}),
+					),
 				)
 				yield* Effect.sync(() => {
 					void client.idle().catch(() => {})

--- a/apps/server/src/services/inbox-health-probe.integration.test.ts
+++ b/apps/server/src/services/inbox-health-probe.integration.test.ts
@@ -5,7 +5,7 @@ process.env['DATABASE_URL'] ??=
 	'postgresql://batuda:batuda@localhost:5433/batuda'
 process.env['EMAIL_HEALTH_PROBE_INTERVAL_SEC'] ??= '900'
 
-import { Effect, Layer } from 'effect'
+import { Effect, Layer, Logger, References } from 'effect'
 import { SqlClient } from 'effect/unstable/sql'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
@@ -58,6 +58,31 @@ const provideTestLayers = (
 		Layer.provide([stubCrypto, stubTransport(probeImpl)]),
 		Layer.provide(PgLive),
 	)
+
+// Reads back every line an effect writes. Annotations sit on the fiber rather
+// than on the log options, so they are read the way the built-in formatters
+// read them.
+const captureLines = () => {
+	const lines: Array<{
+		level: string
+		message: string
+		annotations: Record<string, unknown>
+	}> = []
+	const layer = Logger.layer([
+		Logger.make(options => {
+			lines.push({
+				level: String(options.logLevel),
+				message: String(options.message),
+				annotations: options.fiber.getRef(
+					References.CurrentLogAnnotations,
+				) as Record<string, unknown>,
+			})
+		}),
+	]).pipe(
+		Layer.provideMerge(Layer.succeed(References.MinimumLogLevel, 'Debug')),
+	)
+	return { lines, layer }
+}
 
 describe('InboxHealthProbe', () => {
 	let inboxId: string
@@ -307,6 +332,76 @@ describe('InboxHealthProbe', () => {
 			)
 			expect(grant?.grantStatus).toBe('connected')
 			expect(grant?.grantLastError).toBeNull()
+		})
+	})
+	// A round that finds nothing wrong writes only Debug lines per mailbox,
+	// and production keeps Debug out. Without a line of its own, a stopped
+	// poller and a healthy one are told apart by nothing at all.
+	describe('the line a whole round leaves behind', () => {
+		const roundLine = (
+			lines: ReadonlyArray<{ annotations: Record<string, unknown> }>,
+		) => lines.find(line => line.annotations['event'] === 'inbox.probe_round')
+
+		it('should report a passing round at info, counting the mailboxes it checked', async () => {
+			// GIVEN the seeded inbox is active AND the probe will succeed
+			const { lines, layer: capture } = captureLines()
+
+			// WHEN the probe walks a round
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const probe = yield* InboxHealthProbe
+					yield* probe.tick
+				}).pipe(
+					Effect.provide(provideTestLayers(() => Effect.void)),
+					Effect.provide(capture),
+				) as Effect.Effect<void, never, never>,
+			)
+
+			// THEN one info line should account for every mailbox in the round
+			const round = roundLine(lines)
+			expect(round).toBeDefined()
+			const checked = round?.annotations['inbox.probe.checked'] as number
+			expect(checked).toBeGreaterThanOrEqual(1)
+			expect(round?.annotations['inbox.probe.passed']).toBe(checked)
+			expect(round?.annotations['inbox.probe.failed']).toBe(0)
+			expect(
+				lines.find(line => line.annotations['event'] === 'inbox.probe_round')
+					?.level,
+			).toBe('Info')
+		})
+
+		it('should count a mailbox that did not pass against the round', async () => {
+			// GIVEN a probe that is turned away by the mail server
+			const { lines, layer: capture } = captureLines()
+
+			// WHEN the probe walks a round
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const probe = yield* InboxHealthProbe
+					yield* probe.tick
+				}).pipe(
+					Effect.provide(
+						provideTestLayers(creds =>
+							Effect.fail(
+								new GrantAuthFailed({
+									inboxId: creds.inboxId,
+									reason: 'invalid_credentials',
+									detail: 'turned away',
+								}),
+							),
+						),
+					),
+					Effect.provide(capture),
+				) as Effect.Effect<void, never, never>,
+			)
+
+			// THEN the round should own up to the failure rather than counting it as a pass
+			const round = roundLine(lines)
+			expect(round?.annotations['inbox.probe.failed']).toBeGreaterThanOrEqual(1)
+			expect(round?.annotations['inbox.probe.checked']).toBe(
+				(round?.annotations['inbox.probe.passed'] as number) +
+					(round?.annotations['inbox.probe.failed'] as number),
+			)
 		})
 	})
 })

--- a/apps/server/src/services/inbox-health-probe.ts
+++ b/apps/server/src/services/inbox-health-probe.ts
@@ -154,6 +154,8 @@ export class InboxHealthProbe extends Context.Service<InboxHealthProbe>()(
 						: Effect.logWarning('Mailbox check did not pass').pipe(
 								Effect.annotateLogs(facts),
 							)
+					// Handed back so the round can say how it went as a whole.
+					return state
 				}).pipe(
 					// One mailbox whose answer cannot be written down must not cost the
 					// others their turn. A lost permission or a key that fails to
@@ -167,13 +169,34 @@ export class InboxHealthProbe extends Context.Service<InboxHealthProbe>()(
 								inboxId: inbox.id,
 								cause: boundedCause(cause),
 							}),
+							// A check we could not write down is not a check that
+							// passed, so the round counts it against itself.
+							Effect.andThen(Effect.succeed('unrecorded' as const)),
 						),
 					),
 				)
 
 			const tick = Effect.gen(function* () {
 				const rows = yield* activeInboxes
-				yield* Effect.forEach(rows, probeOne, { concurrency: 4 })
+				const outcomes = yield* Effect.forEach(rows, probeOne, {
+					concurrency: 4,
+				})
+				// The one line a round that found nothing wrong still writes.
+				// Production keeps Debug out of the logs, so without this a
+				// poller that has stopped and a poller with good news look the
+				// same from outside: no line either way.
+				yield* Effect.logInfo('Mailbox checks ran').pipe(
+					Effect.annotateLogs({
+						event: 'inbox.probe_round',
+						'inbox.probe.checked': outcomes.length,
+						'inbox.probe.passed': outcomes.filter(
+							outcome => outcome === 'connected',
+						).length,
+						'inbox.probe.failed': outcomes.filter(
+							outcome => outcome !== 'connected',
+						).length,
+					}),
+				)
 			})
 
 			return { tick, intervalSec } as const

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -42,7 +42,7 @@ It rides two ways on purpose: onto the request's record, which lands on the clos
 The record alone is not enough, because it is only read when the work ends: a business event written halfway through a request would name no tenant.
 Two places say it a second time on purpose, and neither is redundant.
 The MCP transport records it before entering the scope, because a call can fail on the way there — reading its body, or writing down which client it came from — and a request that got as far as resolving a tenant should say which one.
-The mail worker has no request and no scope at all, so `email.received` names the tenant itself.
+The mail worker has no request and no scope at all, so every line it writes names the tenant itself — `email.received`, and both ways a sync pass can fail.
 
 ### Event names
 
@@ -68,10 +68,13 @@ The mail worker has no request and no scope at all, so `email.received` names th
 | `email.sent_copy_failed`       | The message went out; keeping our own copy did not          |
 | `email.sent_append_failed`     | The message went out; filing it in Sent did not             |
 | `email.staging_purge_failed`   | Attachments outlived the message they went with             |
+| `email.folder_read_failed`     | A folder would not open, so nothing new was read from it    |
+| `email.idle_wait_failed`       | Waiting for the mail server to report a change failed       |
 | `inbox.created`                | A mailbox was connected                                     |
 | `inbox.probed`                 | A mailbox check that did not pass (a clean one is `debug`)  |
 | `inbox.probe_unrecorded`       | A mailbox was checked but the answer could not be stored    |
 | `inbox.probe_started`          | The recurring mailbox check began, and how often it runs    |
+| `inbox.probe_round`            | A round of checks finished, and how many passed             |
 | `inbox.probe_round_failed`     | A whole round of checks failed — the poller, not a mailbox  |
 | `mail_worker.heartbeat`        | The mail worker is still running, repeated on a timer       |
 | `webhook.fired`                | Webhook fan-out triggered                                   |
@@ -105,6 +108,11 @@ A mailbox check carries `inbox.probe.outcome` (`connected`, `auth_failed`, `conn
 It also carries `imap.host` and `imap.port`, which name the provider without naming anybody.
 What the mail server itself said never travels: those words are about somebody's account, so they stay on the mailbox row where its owner can read them.
 A check that passed is only the poller saying it is still polling, so it is written at `debug` and production keeps none of them.
+So every round also writes one `inbox.probe_round` line at `info`, carrying `inbox.probe.checked`, `inbox.probe.passed` and `inbox.probe.failed`.
+Without it a poller that has stopped and a poller with nothing to report look the same from outside — no line either way — and on 2026-09-12 that absence was read as the poller being dead when nothing showed it either way.
+
+A failure in the worker names the folder it was about, because the two folders fail for different reasons: `INBOX` not opening stops mail coming in, and `Sent` not opening only stops our own copies being matched up.
+`email.idle_wait_failed` used to go down as a bare stack with no event name at all, which no query could group, count or alert on.
 
 ### Levels
 
@@ -151,7 +159,8 @@ Routes whose URL itself carries a secret are exempt from tracing entirely rather
 | **Interaction Logging**  | `interaction.logged`, `task.created`                                  | Drives daily work          |
 | **Email Outbound**       | `email.sent`, `email.replied`, `email.draft_sent`, `email.failed`     | Primary outreach channel   |
 | **Email Inbound**        | `email.received`, `interaction.logged`                                | Reply tracking             |
-| **Mailbox Health**       | `inbox.created`, `inbox.probed`                                       | A dead mailbox stops both  |
+| **Mailbox Health**       | `inbox.created`, `inbox.probed`, `inbox.probe_round`                  | A dead mailbox stops both  |
+| **Mail Sync**            | `email.folder_read_failed`, `email.idle_wait_failed`                  | Mail silently stops here   |
 | **Webhook Fan-out**      | `webhook.fired`, `webhook.failed`                                     | Integration reliability    |
 | **Page Publishing**      | `page.published`, `page.viewed`                                       | Sales page effectiveness   |
 | **MCP Tool Calls**       | `mcp.auth.rejected`; the tool and its outcome on the request's record | Agent workflow reliability |
@@ -202,11 +211,18 @@ As a solo operation there is no on-call rotation or war room. Two questions matt
 | **High Error Rate**  | > 10% API 5xx responses in 15 min             | High     |
 | **Email Failures**   | > 5 consecutive email send failures           | High     |
 | **Mailbox Refused**  | The same mailbox fails its check for > 30 min | High     |
+| **Mail Not Syncing** | One mailbox fails to read a folder for > 1 h  | High     |
+| **Checks Stopped**   | No `inbox.probe_round` line over 45 min       | High     |
 | **Webhook Failures** | > 20% webhook 5xx responses in 15 min         | High     |
 
 Mailbox Refused is the one that says a tenant is cut off rather than that a request went wrong.
 A mailbox whose credentials stop working stops that tenant's mail in both directions, and it is silent by construction: nobody is waiting on the check, so the only place it surfaces is `inbox.probed`.
 It is held to one mailbox failing repeatedly rather than to a count across all of them, because a provider having a bad minute and a password that has actually been revoked look identical in a single check.
+
+Mail Not Syncing catches the other way a tenant goes quiet: the credentials are accepted, the check passes, and the folders still will not open, so no mail moves.
+Checks Stopped is what makes the silence of a passing check safe to rely on, since a round that never runs writes nothing and a round that finds nothing wrong now writes one line.
+
+**When counting these, filter on `meta.signal_type`.** A business event inside a request leaves both a log record and a span, by design — so a count that does not pick one reads exactly double, and a threshold written that way means half what it says.
 
 **Telemetry Silent is the one alert that cannot be raised from inside.** Every other row above is a question asked of the records, so it needs the records to be arriving. This one has to be evaluated by the vendor, environment-wide, so it still fires when the services are stopped or cut off and cannot report for themselves — the gap that let the 2026-08-31 outage run seven hours unnoticed while `/health` answered 200 throughout. Note the consequence: once it fires it stays fired until export is restored, so it cannot warn about a second outage in the meantime.
 


### PR DESCRIPTION
## What

When a customer's mailbox stops taking in mail, the logs should be able to answer two questions: whose mailbox is it, and is anything still checking. Right now they answer neither. In production three mailboxes have been failing to open their folders for days, and the line recording it — 532 of them a day — names no customer at all, so there is no way to filter it down to the organisation affected. This makes the email side of the CRM (the `server` and `mail-worker` surfaces) say who every mail failure is about, and gives the recurring mailbox check a line you can actually see.

The thing that pushed me to it: earlier today I read the checker's silence as the checker being dead, and it was not — a check that passes is recorded at the quietest level, which production throws away. The absence of news was indistinguishable from bad news, and I got it wrong in exactly the way a person on call would.

## Changes

**Touches:** the mail worker's per-mailbox sync loop (the part that reads folders and then waits for the mail server to announce new messages), the recurring mailbox checker that lives in the server, and the observability guide that documents both.

- The line for a folder that would not open, `email.folder_read_failed`, now names the customer. Measured in production over 24 hours: 532 of these, across 3 mailboxes, and 0 distinct organisation ids — the field was simply never set. The worker serves every mailbox we hold and has no incoming request to inherit a tenant from, so each line has to name it itself.
- The failure to wait for the mail server had no event name whatsoever — just a raw stack trace, 133 a day, that no query could group, count, or alert on. It is now `email.idle_wait_failed`, with the customer and the folder.
- Every round of the mailbox checker writes one visible line, `inbox.probe_round`, counting how many mailboxes it checked, passed and failed. A round that finds nothing wrong previously wrote nothing at all, so a checker that had stopped and a healthy one looked identical.
- A sync pass where a folder would not open no longer refreshes that mailbox's last-seen time (`grant_last_seen_at`). It had been reporting good health on every pass while no mail moved, which would have defeated any "nothing seen for an hour" alarm before one could be built.

## Impact

- **Two release targets, and the fields do not exist until both ship.** The checker line comes from `server`; the two mail lines come from `mail-worker`. Releasing one leaves the other's lines unchanged. Nothing breaks in the meantime — these are additions.
- **Nothing touching which organisation can see what (row-level security) changed**, and no database role changed. The recurring checker still does its database work as `app_service` inside one transaction per piece of work, exactly as before.
- **No schema change and no migration**, so there is no ordering constraint against the server tag.
- **No new environment variables**, no change to the shape of any API response (`packages/controllers` and `packages/domain` are untouched), and no change to how requests are authenticated or routed.
- **One behavioral change outside logging:** the skipped last-seen refresh above. I checked every reader of that column before changing it — only the inboxes screen in `apps/internal` displays it, and nothing uses it as a claim lock or lease, so no mailbox can be re-claimed or dropped as a result. The visible effect is that "last seen" now goes stale precisely when mail stops flowing, which is the point.
- **Three new event names mean any saved Honeycomb query will not know them yet.** The two new alerts I documented (`Mail Not Syncing`, `Checks Stopped`) are written down but deliberately not created — changing live alerting on a running system is yours to approve.

## Review guide

Start with `apps/mail-worker/src/inbox-session.ts` — that is where the real behavior is. The riskiest four lines are the last-seen gate: `readFailed` is declared inside the `while` loop so it resets each pass, and `markHealthy` is now skipped when any folder in that pass failed. Worth a second opinion on one judgment call I made there: if `INBOX` reads fine and `Sent` does not, I treat the whole pass as unhealthy rather than partially healthy. I chose the conservative reading because the permissive one is what produced the blind spot, but you may prefer the opposite.

I moved the two log lines into small exported builders (`folderReadFailed`, `idleWaitFailed`) so the tests can read back what they carry. That mirrors `onImapClientError`, which already sits exported in that file for the same reason — it is a seam for testing, not a refactor.

`apps/server/src/services/inbox-health-probe.ts` is the simpler half: each check now hands its outcome back so the round can count them.

`docs/observability.md` is prose only — skim or skip.

Two things I did not resolve: `captureLines` is now duplicated in a third test file. I left it copied rather than creating a shared test-helper module, because that is a new cross-app boundary and you have asked to be consulted on those. And the last-seen gate has no test — see `## Tests`.

I did not run `/security-review`: this touches no authentication, no tenant scoping, no parser, no crypto, no upload, and no external input. `boundedCause` still bounds every cause that reaches the logs, so no unbounded provider text can ride along. The `snyk_code_scan` tool is not available in this session.

## Tests

- The two mail lines are covered by unit tests that read back every annotation each one writes — the event name, the organisation, the mailbox, the folder — plus one asserting the wait failure cannot be mistaken for a folder-read failure, so a count of one is never silently the other.
- The checker's round line is covered by two integration tests against a real database: one for a clean round, one where a mailbox is turned away, asserting the counts add up and that the line is at the visible level rather than the quiet one.
- **The last-seen gate has no test.** Exercising it means driving an endless session loop against a live IMAP server, and no harness for that exists — the round-trip integration test deliberately bypasses `runInboxSession` and calls the folder sync directly. I verified it by auditing every reader of the column instead of by executing it. Flagging it rather than claiming coverage I do not have.

## Verification

- `pnpm install` (no lockfile drift), `pnpm -w check-types` 14/14, `pnpm -w test` 23/23 tasks, `pnpm -w build` 14/14 — all run on this commit.
- Server integration suite against a real Postgres: 118 files / 939 tests pass. Mail-worker: 52 unit, 53 integration.
- Negative checks, to prove the tests bite: removing the organisation id fails 2 tests, and downgrading the round line to the quiet level fails the level assertion — which is the whole point of that line.
- Live stack: booted the server with a 20-second check interval and watched it write `Mailbox checks ran · event=inbox.probe_round · checked=7 · passed=7 · failed=0`, repeating 3 times on schedule. So the line is real, at the right level, and the loop keeps running — which is what makes a "checks stopped" alarm trustworthy.
- **Not verified live: the two mail-worker lines.** Forcing a folder-open failure means breaking the IMAP server mid-sync, and the local one (GreenMail) is shared across every worktree on this machine, so I was not willing to take it down. They are covered by the unit tests above.
- Not a UI change, so there is nothing to screenshot.

## Deferred

- **The actual outage is untouched.** Three mailboxes still fail every folder open with `Connection not available`, and have for days. This PR makes that failure legible; it does not fix it. That is a reconnection bug in the session handling and wants its own issue and its own PR — on impact it outranks everything here.
- Creating the two documented alerts in Honeycomb, which needs your go-ahead and both releases first.
